### PR TITLE
Add support for retrieving config data from a URL

### DIFF
--- a/midas-author/lps/src/environments/environment.prod.ts
+++ b/midas-author/lps/src/environments/environment.prod.ts
@@ -12,6 +12,7 @@ import { LPSConfig } from 'oarlps';
 
 export const context = {
     production: true,
+    configEndpoint: "assets/config.json",
     useMetadataService: false,
     useCustomizationService: true
 };

--- a/midas-author/lps/src/environments/environment.ts
+++ b/midas-author/lps/src/environments/environment.ts
@@ -13,6 +13,7 @@ import { LPSConfig } from 'oarlps';
 
 export const context = {
     production: false,
+    configEndpoint: null,          // set to "assets/config.json" to pull from server
     useMetadataService: true,
     useCustomizationService: true
 };

--- a/oar-lps/libs/oarlps/src/environments/environment.ts
+++ b/oar-lps/libs/oarlps/src/environments/environment.ts
@@ -13,6 +13,7 @@ import { LPSConfig } from '../lib/config/config';
 
 export const context = {
     production: false,
+    configEndpoint: "assets/config.json",          // set to "assets/config.json"
     useMetadataService: false,
     useCustomizationService: false
 };

--- a/oar-lps/libs/oarlps/src/environments/ienvironment.ts
+++ b/oar-lps/libs/oarlps/src/environments/ienvironment.ts
@@ -2,6 +2,7 @@ import { LPSConfig } from '../lib/config/config';
 
 export interface Context {
     production: boolean;
+    configEndpoint?: string|null;
     useMetadataService: boolean;
     useCustomizationService: boolean;
 }

--- a/oar-lps/libs/oarlps/src/lib/config/config.service.spec.ts
+++ b/oar-lps/libs/oarlps/src/lib/config/config.service.spec.ts
@@ -41,7 +41,7 @@ describe("config.service newConfigService", function() {
     it("angular-env", function() {
         let plid : Object = "browser";
         let ts = new TransferState();
-        let svc = cfgsvc.newConfigService(plid, ts);
+        let svc = cfgsvc.newConfigService(ngenv, plid, ts);
 
         expect(svc instanceof cfgsvc.ConfigService).toBe(true);
         expect(svc instanceof cfgsvc.AngularEnvironmentConfigService).toBe(true);
@@ -61,7 +61,22 @@ describe("config.service newConfigService", function() {
         let ts = new TransferState();
         ts.set<cfg.LPSConfig>(cfgsvc.CONFIG_TS_KEY, data);
         
-        let svc = cfgsvc.newConfigService(plid, ts);
+        let svc = cfgsvc.newConfigService(ngenv, plid, ts);
+
+        expect(svc instanceof cfgsvc.ConfigService).toBe(true);
+        expect(svc instanceof cfgsvc.TransferStateConfigService).toBe(true);
+
+        let ac : cfg.AppConfig = svc.getConfig() as cfg.AppConfig;
+        expect(ac instanceof cfg.AppConfig).toBe(true);
+        expect(ac.status).toBe("Dev Version");
+        expect(ac["mode"]).toBe("prod");
+        expect(ac["source"]).toBe("transfer-state");
+    });
+
+    it("remote file", function() {
+        let env = cfgsvc.deepCopy(negenv);
+        env.context.configEndpoint("assets/config.json");
+        let svc = cfgsvc.newConfigService(ngenv, plid, ts);
 
         expect(svc instanceof cfgsvc.ConfigService).toBe(true);
         expect(svc instanceof cfgsvc.TransferStateConfigService).toBe(true);


### PR DESCRIPTION
This PR extends the config module within the oar-lps library to add support for retrieving configuration from a remote URL (courtesy of the `RemoteFileConfigService` implementation).  The `ConfigService` factory function was updated to check for the `configEndpoint` property in the `context` object from the Angular build-time environment (see [`environment.ts`](https://github.com/usnistgov/oar-pdr-angular/blob/feature/bs-config-fetch/midas-author/lps/src/environments/environment.ts)).  