### PR TITLE
RPA apps: enable apps to receive configuration from configuration server

### DIFF
--- a/pdr-rpa/pdr-rpa-approve/src/app/app.module.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/app/app.module.ts
@@ -15,31 +15,34 @@ import { RouterModule } from '@angular/router';
 import { HttpClientModule } from '@angular/common/http';
 import { AppRoutingModule } from './app-routing.module';
 import { UnescapeHTMLPipe } from './pipe/unescape-html.pipe';
+import { ServiceModule } from './service/service.module';
 import { FrameModule } from 'oarng';
 
 @NgModule({
-  declarations: [
-    AppComponent,
-    UnescapeHTMLPipe
-  ],
-  imports: [
-    FrameModule,
-    BrowserModule, 
-    FormsModule, 
-    PanelModule, 
-    MessagesModule, 
-    MessageModule, 
-    DropdownModule, 
-    CardModule, 
-    ChipModule, 
-    ButtonModule, 
-    ProgressSpinnerModule, 
-    OverlayPanelModule,
-    AppRoutingModule,
-    HttpClientModule,
-    RouterModule.forRoot([])
-  ],
-  providers: [],
-  bootstrap: [AppComponent]
+    declarations: [
+        AppComponent,
+        UnescapeHTMLPipe
+    ],
+    imports: [
+        FrameModule,
+        BrowserModule, 
+        FormsModule, 
+        PanelModule, 
+        MessagesModule, 
+        MessageModule, 
+        DropdownModule, 
+        CardModule, 
+        ChipModule, 
+        ButtonModule, 
+        ProgressSpinnerModule, 
+        OverlayPanelModule,
+        AppRoutingModule,
+        HttpClientModule,
+
+        ServiceModule,
+        RouterModule.forRoot([])
+    ],
+    providers: [],
+    bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/pdr-rpa/pdr-rpa-approve/src/app/model/config.model.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/app/model/config.model.ts
@@ -1,0 +1,11 @@
+export interface Configuration {
+    /**
+     * the base URL to assume for this application
+     */
+    baseUrl: string;
+
+    /**
+     * other parameters are allowed
+     */
+    [paramName: string]: any;
+}

--- a/pdr-rpa/pdr-rpa-approve/src/app/service/config.service.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/app/service/config.service.ts
@@ -1,0 +1,72 @@
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable, Subject, throwError } from "rxjs";
+import { catchError, tap } from "rxjs/operators";
+
+import { Configuration } from "../model/config.model";
+import { environment } from "../../environments/environment";
+
+/**
+ * Service responsible for providing configuration data for the application.
+ * It loads the configuration from a given file and provides access to it
+ * throughout the app.
+ */
+@Injectable()
+export class ConfigurationService {
+
+    configUrl = environment.configUrl;
+    config : Configuration = null;
+
+    constructor(private http: HttpClient) { }
+
+    loadConfig(data: any) : void {
+        this.config = data as Configuration;
+        console.log("app configuration loaded");
+    }
+
+    /**
+     * Get the configuration object from the config URL.
+     * @returns An observable containing the configuration object.
+     */
+    public fetchConfig(configURL: string = null): Observable<any> {
+        if (! configURL)
+            configURL = this.configUrl;
+        return this.http.get<Configuration>(configURL, {responseType: "json"}).pipe(
+            catchError(this.handleError)
+        ).pipe( tap(cfg => (this.loadConfig(cfg))) );
+    }
+
+    /**
+     * return the (already loaded) configuration data.  It is expected that when this 
+     * method is call that the configuration was already fetched (via fetchConfg()) at 
+     * application start-up.  
+     */
+    public getConfig(): Configuration {
+        if (! this.config) 
+            return { baseUrl: "/" } as Configuration;
+        return this.config;
+    }
+
+    /**
+     * Handle the HTTP errors.
+     * @param error The error object.
+     * @returns An observable containing the error message.
+     */
+    private handleError(error: any) {
+        let errorMessage = '';
+        if (error.error instanceof ErrorEvent) {
+            // Get client-side error
+            errorMessage = error.error.message;
+        } else {
+            // Get server-side error
+            errorMessage = `Error Code: ${error.status}\nMessage: ${error.message}`;
+        }
+        window.alert(errorMessage);
+        return throwError(() => {
+            return errorMessage;
+        });
+    }
+}
+
+
+

--- a/pdr-rpa/pdr-rpa-approve/src/app/service/rpa.service.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/app/service/rpa.service.ts
@@ -3,7 +3,9 @@ import { Injectable } from "@angular/core";
 import { Observable, throwError } from "rxjs";
 import { catchError, retry } from "rxjs/operators";
 import { formatDate } from '@angular/common';
+
 import { ApprovalResponse, Record, RecordWrapper, UserInfo } from "../model/record";
+import { ConfigurationService } from './config.service';
 import { environment } from "../../environments/environment";
 
 @Injectable()
@@ -11,9 +13,10 @@ export class RPAService {
 
     baseUrl: string;
 
-    constructor(private http: HttpClient) {
-        this.baseUrl = environment.requestHandlerUrl;
-     }
+    constructor(private http: HttpClient, private configSvc: ConfigurationService) {
+        // Get the base URL from the environment
+        this.baseUrl = this.configSvc.getConfig().baseUrl;
+    }
 
     // Http Options
     httpOptions = {

--- a/pdr-rpa/pdr-rpa-approve/src/app/service/service.module.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/app/service/service.module.ts
@@ -1,0 +1,24 @@
+import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { ConfigurationService } from './config.service';
+import { RPAService } from './rpa.service';
+
+export function configFetcherFactory(configSvc: ConfigurationService) {
+    return () => { 
+        return configSvc.fetchConfig().toPromise();
+    };
+}
+
+@NgModule({
+    providers: [
+        HttpClient,
+        ConfigurationService,
+        RPAService,
+        { provide: APP_INITIALIZER, useFactory: configFetcherFactory,
+          deps: [ ConfigurationService ], multi: true }
+    ]
+})
+export class ServiceModule { }
+
+export { ConfigurationService, RPAService }

--- a/pdr-rpa/pdr-rpa-approve/src/assets/config.json
+++ b/pdr-rpa/pdr-rpa-approve/src/assets/config.json
@@ -1,0 +1,3 @@
+{
+    "baseUrl": "http://localhost:4202"
+}

--- a/pdr-rpa/pdr-rpa-approve/src/environments/environment.prod.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  requestHandlerUrl: 'http://data.nist.gov/od/ds/rpa'
+  configUrl: 'assets/config.json'
 };

--- a/pdr-rpa/pdr-rpa-approve/src/environments/environment.ts
+++ b/pdr-rpa/pdr-rpa-approve/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  requestHandlerUrl: 'http://localhost:8083/od/ds/rpa'
+  configUrl: 'assets/config.json'
 };
 
 /*

--- a/pdr-rpa/pdr-rpa-request/src/app/app.module.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { NgModule, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { PanelModule } from 'primeng/panel';
 import { HttpClientModule } from '@angular/common/http';
@@ -20,26 +20,10 @@ import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FrameModule } from 'oarng';
 import { RECAPTCHA_SETTINGS, RecaptchaFormsModule, RecaptchaModule, RecaptchaSettings } from 'ng-recaptcha';
-import { ConfigurationService } from './service/config.service';
+import { ServiceModule, ConfigurationService } from './service/service.module';
 import { Observable } from 'rxjs';
-import { Secrets } from './model/secrets.model';
 import { tap } from 'rxjs/operators';
 import { environment } from '../environments/environment';
-
-/**
- * The secretsLoadingFactory function returns a function that, when called, 
- * sends an HTTP GET request to the secrets URL and loads the secrets into the ConfigurationService. 
- * 
- * @param configService 
- * @returns 
- */
-function secretsLoadingFactory(configService: ConfigurationService): () => Observable<Secrets> {
-    return () => configService.loadSecrets(environment.secretsUrl).pipe(
-        tap(secrets => {
-            configService.secrets = secrets;
-        })
-    );
-}
 
 /**
  * The recaptchaApiKeyFactory function returns an object with the Recaptcha site key 
@@ -49,7 +33,7 @@ function secretsLoadingFactory(configService: ConfigurationService): () => Obser
  * @returns 
  */
 function recaptchaApiKeyFactory(configService: ConfigurationService): RecaptchaSettings {
-    return { siteKey: configService.secrets.recaptchaApiKey };
+    return { siteKey: configService.getConfig().recaptchaApiKey };
 }
 
 @NgModule({
@@ -77,21 +61,16 @@ function recaptchaApiKeyFactory(configService: ConfigurationService): RecaptchaS
         OverlayPanelModule,
         RecaptchaModule,
         RecaptchaFormsModule,
+
+        ServiceModule,
         RouterModule.forRoot([])
     ],
     providers: [
         {
-            // run the secretsLoadingFactory function before the app starts
-            provide: APP_INITIALIZER,
-            useFactory: secretsLoadingFactory,
-            deps: [ConfigurationService],
-            multi: true
-        },
-        {
             // provide the Recaptcha site key to the Recaptcha module.
             provide: RECAPTCHA_SETTINGS,
             useFactory: recaptchaApiKeyFactory,
-            deps: [ConfigurationService]
+            deps: [ConfigurationService, APP_INITIALIZER]
         }
     ],
     bootstrap: [AppComponent]

--- a/pdr-rpa/pdr-rpa-request/src/app/model/config.model.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/model/config.model.ts
@@ -1,0 +1,16 @@
+export interface Configuration {
+    /**
+     * the base URL to assume for this application
+     */
+    baseUrl: string;
+
+    /**
+     * token used to interact with Google's reCAPTCHA service
+     */
+    recaptchaApiKey: string;
+
+    /**
+     * other parameters are allowed
+     */
+    [paramName: string]: any;
+}

--- a/pdr-rpa/pdr-rpa-request/src/app/model/secrets.model.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/model/secrets.model.ts
@@ -1,3 +1,0 @@
-export interface Secrets {
-    recaptchaApiKey: string;
-}

--- a/pdr-rpa/pdr-rpa-request/src/app/service/rpa.service.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/service/rpa.service.ts
@@ -2,7 +2,9 @@ import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable, throwError } from "rxjs";
 import { catchError, retry, tap } from "rxjs/operators";
+
 import { Record, RecordWrapper, UserInfo } from "../model/record.model";
+import { ConfigurationService } from './config.service';
 import { environment } from "../../environments/environment";
 
 /**
@@ -16,9 +18,9 @@ export class RPAService {
     private readonly REQUEST_FORM_PATH = "/request/form";
     baseUrl: string;
 
-    constructor(private http: HttpClient) {
+    constructor(private http: HttpClient, private configSvc: ConfigurationService) {
         // Get the base URL from the environment
-        this.baseUrl = environment.requestHandlerUrl;
+        this.baseUrl = this.configSvc.getConfig().baseUrl;
     }
 
     // Http Options

--- a/pdr-rpa/pdr-rpa-request/src/app/service/service.module.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/service/service.module.ts
@@ -1,0 +1,24 @@
+import { NgModule, APP_INITIALIZER } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { ConfigurationService } from './config.service';
+import { RPAService } from './rpa.service';
+
+export function configFetcherFactory(configSvc: ConfigurationService) {
+    return () => { 
+        return configSvc.fetchConfig().toPromise();
+    };
+}
+
+@NgModule({
+    providers: [
+        HttpClient,
+        ConfigurationService,
+        RPAService,
+        { provide: APP_INITIALIZER, useFactory: configFetcherFactory,
+          deps: [ ConfigurationService ], multi: true }
+    ]
+})
+export class ServiceModule { }
+
+export { ConfigurationService, RPAService }

--- a/pdr-rpa/pdr-rpa-request/src/assets/config.json
+++ b/pdr-rpa/pdr-rpa-request/src/assets/config.json
@@ -1,0 +1,4 @@
+{
+    "baseUrl": "http://localhost:4201",
+    "recaptchaApiKey": "6Lc7EsgkAAAAAFs28XHZiEJRQZ6Z4_DLGtp2AH5E"
+}

--- a/pdr-rpa/pdr-rpa-request/src/environments/environment.prod.ts
+++ b/pdr-rpa/pdr-rpa-request/src/environments/environment.prod.ts
@@ -1,8 +1,8 @@
 export const environment = {
   production: true,
-  requestHandlerUrl: 'https://data.nist.gov/od/rpa', // TODO: change this?
-  configUrl: 'assets/datasets.yaml',
+  datasetsConfigUrl: 'assets/datasets.yaml',
   countriesUrl: 'assets/countries.json',
-  secretsUrl: 'assets/secrets.prod.json',
+  configUrl: 'assets/config.json',
   debug: false
 };
+

--- a/pdr-rpa/pdr-rpa-request/src/environments/environment.ts
+++ b/pdr-rpa/pdr-rpa-request/src/environments/environment.ts
@@ -4,10 +4,9 @@
 
 export const environment = {
   production: false,
-  requestHandlerUrl: 'http://localhost:8083/od/ds/rpa',
-  configUrl: 'assets/datasets.yaml',
+  datasetsConfigUrl: 'assets/datasets.yaml',
   countriesUrl: 'assets/countries.json',
-  secretsUrl: 'assets/secrets.json',
+  configUrl: 'assets/config.json',
   debug: false
 };
 


### PR DESCRIPTION
This PR establishes into the RPA apps a `ConfigurationService` that can integrate with the configuration service under the `oar-docker` context.  This was motivated by an `oar-docker` integration issue with the `requestHandlerUrl` parameter: this was being set at build time (via `environment.ts`) whereas it needs to be set at runtime so that we can build platform-independent build artifacts.  The OAR-standard way to achieve this is via runtime-set configuration parameters that come from a configuration service.  As we expect to need to support more configuration properties in the future, this PR establishes the configuration framework that can integrate with `oar-docker`.  

The PR makes the following changes to the RPA apps:
  * In each RPA app, a `ConfigurationService` has been set up to provide configuration properties, retrieving them from a static file, `assets/config.json`.  A default `assets/config.json` is provided as a default for the development context; in the `oar-docker` context, this file would get overwritten with data from the configuration service.  (Currently, only the `RPAService` in each app need access to this `ConfigurationService`.)
  * The `Configuration` interface (in `app/model/config.model.ts`) defines the supported configuration parameters.
  * The `requestHandlerUrl` enviroment parameter is replaced with the `baseUrl` configuration parameter.  
  * In the `pdr-rpa-request` app, the recaptha key is moved from `Secrets` to `Configuration`, and the separate `Secrets` model is deprecated.  
  * The services, `ConfigurationService` and `RPAService`, have been wrapped into a new `ServiceModule` (in `app/service/service.module.ts`); this module handles ensuring the configuration data is loaded during app initialization (via `APP_INITIALIZER`).