### PR TITLE
Feature/dap35 add version

### DIFF
--- a/midas-author/lps/src/assets/site-constants/question-help.json
+++ b/midas-author/lps/src/assets/site-constants/question-help.json
@@ -2,11 +2,13 @@
 {   
     "general": "This screen allows you to enter the information for creating your publication.  <p><p>On this page, you can:<ul><li>Click on <i class='faa faa-pencil'></i> next to the item you want to enter or update a piece of information,</li><li>Click the <b>Preview</b> button above to see how this page will look to the public with your changes so far, or </li><li>Click on the <b>Save</b> button above to save the changes to your draft and come back to this later.</li></ul><p><p>Click <i class='faa faa-pencil'></i> to the right of each field to edit",
     "title": {
+        "label": "Title",
         "general": "The title should be written in plain language and include sufficient detail to facilitate search and discovery. <p><p> If this publication can be considered a supplement to a literature publication, consider using the same title with an extra annotation, like ': Supplementary Data'.",
         "edit": "Type the title into the input box and then click the <i class='faa faa-check'></i> icon to save.",
         "seealso": "<i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>"
     },
     "authors": {
+        "label": "Authors",
         "general": "This section should list all authors or collaborators whose work falls under one of the 14 roles listed in the <a href='https://credit.niso.org/'>Credit Contributor Roles Taxonomy</a>. Add affiliations and ORCIDs as available.",
         "list": "Click <i class='faa faa-plus'></i> to add authors. Click <i class='faa faa-pencil'></i> to make edits.",
         "add": "Click <i class='faa faa-check'></i> to save.",
@@ -14,30 +16,36 @@
         "dragdrop": "To change the order of authors listed, click on <img src='./assets/images/reorder_s.png'> on the left of each name, drag it to the right place in the list, and release the mouse button to drop it in place."
     },
     "contactPoint": {
+        "label": "Contact Point",
         "general": "Review the name of the NIST contact listed who will respond to questions about this resource. To edit this contact, click <i class='faa faa-pencil'></i>",
         "add": "<i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>",
         "edit": "Click <i class='faa faa-check'></i> to save changes. <p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>"
     },
     "landingPage": {
+        "label": "Visit Home Page",
         "general": "The Home Page is the users' entry point for a resource. It provides contextual information and access to the resource itself (i.e. download links for data). Importantly, the DOI (digital object identifier) will point to this URL. <p><p> If you wish for this NIST Public Data Repository page to your Home Page, leave this box blank and click <i class='faa faa-remove'></i> to close the entry field. If you would like to point to another home page enter the URL here.",
       "add": "<i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>",
         "edit": "Enter a working URL for a homepage other than this repository landing page. Click <i class='faa faa-check'></i> to save changes<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>"
     },
     "description": {
+        "label": "Description",
         "general": "This field is for a human-readable description of your resource that will enable a user to quickly identify whether it is of interest. You may wish to use part of the abstract of a related publication. Avoid copying the entire abstract if the entirety is not relevant to this discrete resource.",
         "edit": "Click <i class='faa faa-check'></i> to save. <p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>"
     },
     "theme":{
+        "label": "Research Topics",
         "general": "You are in Research Topics section where you can select topics from the NIST Research Taxonomy. Select one or more topics that apply to this resource",
         "add": "Click <i class='faa faa-pencil'></i> to select topics for this resource. Click on the arrows to view subtopics. Double-click on a topic to select it for your resource. <p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>",
         "edit": "To edit your Research Topics selections, click on <i class='faa faa-pencil'></i>. Double click on topics to add them. Click <i class='faa faa-trash'></i> to the right of topics to delete them.<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>"
     },
     "keyword": {
+        "label": "Keywords",
         "general": "Add <i>keywords,</i> or subject terms that help both technical and non-technical users to discover this resource. Separate the terms with commas. You may enter up to a maximum of 4,000 characters",
         "add": "Click <i class='faa faa-check'></i> to save.<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>",
         "edit": "Click <i class='faa faa-pencil'></i> to edit your keywords or enter additional keywords. Separate the terms with commas.<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>"
     },
     "components": {
+        "label": "Access Page",
         "general": "You are in the Data Access section. Enter URLs for sites with related information on this resource, e.g. a GitHub repository. Each entry requires the URL, the 'Link text' or Title, and information 'About this link' or a description. Note: this area is not for links to files. To upload and link files use the 'Files' button below.",
         "list": "Click <i class='faa faa-plus'></i> to enter URLs to sites with information related to this resource. Click <i class='faa faa-pencil'></i> to make edits.",
         "add": "Separate each URL with a comma. When all URLS are entered, click <i class='faa faa-check'></i> to save.<p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>",
@@ -45,6 +53,7 @@
         "dragdrop": "To change the order of URLs listed, click on <img src='./assets/images/reorder_s.png'> on the left of each link, drag it to the right place in the list, and release the mouse button to drop it in place.<p><p>"
     },
     "references": {
+        "label": "References",
         "general": "You are in <i>References</i> section where you can add references or citations related to this resource. You may wish to include links to multiple types of resources such as a related publication or a software package. <p><p> <i>[Other Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>",
         "list": "Click <i class='faa faa-plus'></i> to add the URI of a related resource. Click <i class='faa faa-pencil'></i> to make changes to existing References listed here.",
         "add": "Separate each Reference URL with a comma. When all References are entered, click <i class='faa faa-check'></i> to save.<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guidance</a>]</i>",

--- a/midas-author/lps/src/assets/site-constants/question-help.json
+++ b/midas-author/lps/src/assets/site-constants/question-help.json
@@ -27,6 +27,14 @@
       "add": "<i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>",
         "edit": "Enter a working URL for a homepage other than this repository landing page. Click <i class='faa faa-check'></i> to save changes<p><p> <i>[Helpful examples, <a href='https://data.nist.gov/sdp/#/policy'>links to policy and guideance</a>]</i>"
     },
+    "doi": {
+        "label": "Identifier",
+        "general": "Place holder for identifier help."
+    },
+    "version": {
+        "label": "Version",
+        "general": "Placeholder for version help."
+    },
     "description": {
         "label": "Description",
         "general": "This field is for a human-readable description of your resource that will enable a user to quickly identify whether it is of interest. You may wish to use part of the abstract of a related publication. Avoid copying the entire abstract if the entirety is not relevant to this discrete resource.",

--- a/oar-lps/libs/oarlps/src/lib/landing/contact/contact.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/contact/contact.component.html
@@ -21,8 +21,8 @@
                     <span *ngIf="!hasEmail">{{currentContact.fn}}</span>
                 </strong>.
 
-                <i style="cursor: pointer;" class="faa"
-                [ngClass]="{'faa-plus-square-o': !clickContact, 'faa-minus-square-o': clickContact}"
+                <i style="cursor: pointer; margin-left: 0.5rem;" class="faa"
+                [ngClass]="{'faa-caret-right': !clickContact, 'faa-caret-down': clickContact}"
                 aria-hidden="true"
                 (click)="closeContent = !closeContent; clickContact=expandContact();"></i>
 

--- a/oar-lps/libs/oarlps/src/lib/landing/version/version.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/version/version.component.html
@@ -2,9 +2,12 @@
     <span class="" *ngIf="record.version" style="padding-right: 10pt;"> Version: <strong>{{record.version}}</strong></span>
     <span class="" *ngIf="record.versionHistory" style="padding-right: 15pt;">...
         <i style="cursor: pointer;" class="faa" aria-hidden="true"
-            [ngClass]="{'faa-plus-square-o': !clickHistory, 'faa-minus-square-o': clickHistory}"
+            [ngClass]="{'faa-caret-right': !clickHistory, 'faa-caret-down': clickHistory}"
             (click)="closeHistory = !closeHistory; clickHistory = expandHistory();"></i>
     </span>
+
+    <!-- Info button -->
+    <i class="faa faa-info-circle link-icon" (click)="refreshHelpText()" title="About version" ngbTooltip="About version" style="cursor: pointer;margin-right: 10px;"></i> 
 
     <!-- Releases, Last modified and creators -->
     <span class="" *ngIf="record.issued" style="padding-right: 10pt;"> Released:

--- a/oar-lps/libs/oarlps/src/lib/landing/version/version.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/version/version.component.ts
@@ -4,6 +4,8 @@ import { AppConfig } from '../../config/config';
 import { NerdmRes } from '../../nerdm/nerdm';
 import { LandingConstants } from '../constants';
 import { EditStatusService } from '../editcontrol/editstatus.service';
+import { Themes, ThemesPrefs, AppSettings, SectionHelp, SectionPrefs, Sections } from '../../shared/globals/globals';
+import { LandingpageService, HelpTopic } from '../landingpage.service';
 
 interface reference {
     refType?: string,
@@ -24,7 +26,7 @@ interface reference {
 @Component({
     selector: 'pdr-version',
     templateUrl: './version.component.html',
-    styleUrls: [ ]
+    styleUrls: [ '../landing.component.scss' ]
 })
 export class VersionComponent implements OnChanges {
     visibleHistory = false;
@@ -32,6 +34,7 @@ export class VersionComponent implements OnChanges {
     lpssvc : string = null;
     public EDIT_MODES: any = LandingConstants.editModes;
     editMode: string;
+    fieldName = SectionPrefs.getFieldName(Sections.VERSION);
 
     @Input() record: NerdmRes = null;
 
@@ -40,7 +43,8 @@ export class VersionComponent implements OnChanges {
      * @param cfg   the app configuration data
      */
     constructor(private cfg : AppConfig,
-        public editstatsvc: EditStatusService) {
+        public editstatsvc: EditStatusService,
+        public lpService: LandingpageService) {
         this.lpssvc = this.cfg.get('locations.landingPageService',
                                    'https://data.nist.gov/od/id/');
     }
@@ -76,6 +80,7 @@ export class VersionComponent implements OnChanges {
             return "v" + relinfo.version;
         return this.renderRelAsLink(relinfo, "v" + relinfo.version);
     }
+
     renderRelAsLink(relinfo, linktext) {
         let out: string = linktext;
         if (relinfo.location)
@@ -173,6 +178,17 @@ export class VersionComponent implements OnChanges {
             }
         }
     }
+
+    /**
+     * Refresh the help text
+     */
+    refreshHelpText(){
+        let sectionHelp: SectionHelp = {} as SectionHelp;
+        sectionHelp.section = this.fieldName;
+        sectionHelp.topic = HelpTopic[this.editMode];
+
+        this.lpService.setSectionHelp(sectionHelp);
+    }    
 }
 
 /**

--- a/oar-lps/libs/oarlps/src/lib/landing/version/version.module.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/version/version.module.ts
@@ -1,6 +1,6 @@
 import { NgModule }     from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { CollapseModule } from '../collapseDirective/collapse.module';
 import { VersionComponent } from './version.component';
 
@@ -10,7 +10,8 @@ import { VersionComponent } from './version.component';
 @NgModule({
     imports: [
         CommonModule,
-        CollapseModule
+        CollapseModule,
+        NgbModule
     ],
     declarations: [
         VersionComponent

--- a/oar-lps/libs/oarlps/src/lib/shared/globals/globals.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/globals/globals.ts
@@ -91,6 +91,7 @@ export class Sections {
     static readonly CONTACT = 'Contact';
     static readonly VISIT_HOME_PAGE = 'Visit Home Page';
     static readonly DOI = 'DOI';
+    static readonly VERSION = 'Version';
 }
 
 //_fieldName is the field name in Nerdm record
@@ -113,6 +114,7 @@ _fieldName[Sections.SIDEBAR] = "sidebar";
 _fieldName[Sections.CONTACT] = "contactPoint";
 _fieldName[Sections.VISIT_HOME_PAGE] = "landingPage";
 _fieldName[Sections.DOI] = "doi";
+_fieldName[Sections.VERSION] = "version";
 
 let _displayName = {};
 _displayName[GENERAL] = Sections.GENERAL;
@@ -131,6 +133,7 @@ _displayName["sidebar"] = Sections.SIDEBAR;
 _displayName["contactPoint"] = Sections.CONTACT;
 _displayName["landingPage"] = Sections.VISIT_HOME_PAGE;
 _displayName["doi"] = Sections.DOI;
+_displayName["version"] = Sections.VERSION;
 
 export class SectionPrefs {
     private static readonly _lSectionID = _fieldName;

--- a/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.ts
@@ -109,7 +109,10 @@ export class SidebarComponent implements OnInit {
         }   
 
         // Update help title
-        this.title = SectionPrefs.getDispName(sectionHelp.section) + " Help";
+        if(this.helpContentAll[sectionHelp.section]["label"])
+            this.title = this.helpContentAll[sectionHelp.section]["label"].trim() + " Help";
+        else
+            this.title = SectionPrefs.getDispName(sectionHelp.section) + " Help";
 
         this.suggustedSections = this.sidebarService.getSuggestions(this.record, this.resourceType);
         // this.required = this.suggustedSections['required'];

--- a/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.ts
@@ -101,7 +101,7 @@ export class SidebarComponent implements OnInit {
             }
 
             // Add "see also" if available
-            if(this.helpContentAll[sectionHelp.section][HelpTopic["seealso"]])
+            if(this.helpContentAll[sectionHelp.section] &&this.helpContentAll[sectionHelp.section][HelpTopic["seealso"]])
                         this.helpContent += this.helpContentAll[sectionHelp.section][HelpTopic["seealso"]] + "<p><p>";
             
         }else {
@@ -109,7 +109,7 @@ export class SidebarComponent implements OnInit {
         }   
 
         // Update help title
-        if(this.helpContentAll[sectionHelp.section]["label"])
+        if(this.helpContentAll[sectionHelp.section] && this.helpContentAll[sectionHelp.section]["label"])
             this.title = this.helpContentAll[sectionHelp.section]["label"].trim() + " Help";
         else
             this.title = SectionPrefs.getDispName(sectionHelp.section) + " Help";


### PR DESCRIPTION
This checkin is for sgitlab issue #35:
https://sgitlab.nist.gov/oardev/publishing/-/issues/35

This branch was derived from feature/DAP36-doi-help branch.

Changes:
1. Added an "i" icon next to version number. When user clicks on the icon, the help text about version will show up in the help box.
2. Changed the little "+" icon in "Contact" and "Version" section to "caret-right/caret-down" icon.

Steps to test locally:

git clone https://github.com/usnistgov/oar-pdr-angular.git

cd oar-pdr-angular/
git submodule update --init --recursive
cd lib
git checkout integration

cd ..
git checkout feature/inline-editing3

// Install dependencies
npm i --legacy-peer-deps

// Build general lib
npm run build-lib

// Build lps lib
npm run build-oarlps

// Build publishing UI
npm run build-midaslps

// Run publishing UI (in separated terminal window)
npm run start-midaslps
 