### PR TITLE
Fixed bugs when removing last access page and undo reference changes.

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/landing/accesspage/accesspage-list/accesspage-list.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/accesspage/accesspage-list/accesspage-list.component.ts
@@ -141,7 +141,7 @@ export class AccesspageListComponent implements OnInit {
         this.accessPages = [] as NerdmComp[];
         if (this.record[this.fieldName]) {
             this.accessPages = this.selectAccessPages();
-
+            
             // if current page has not been set, set it
             if(this.currentApageIndex == -1 || this.currentApageIndex >= this.accessPages.length || resetIndex){
                 this.currentApage = this.accessPages[0];
@@ -255,6 +255,7 @@ export class AccesspageListComponent implements OnInit {
      */
     removeAccessPage(index: number) {
         this.accessPages.splice(index,1);
+        console.log("this.accessPages=========", this.accessPages);
         // this.currentOrderChanged = true;
         // this.dataCommand.next(MODE.EDIT);
         this.updateMatadata().then((success) => {
@@ -396,7 +397,7 @@ export class AccesspageListComponent implements OnInit {
      */
     updateMatadata(comp: NerdmComp = undefined, compId: string = undefined) {
         let postMessage: any = {};
-
+        console.log("Updating comp:", comp);
         return new Promise<boolean>((resolve, reject) => {
             if(compId && comp) {   // Update specific access page
                 postMessage = JSON.parse(JSON.stringify(comp));
@@ -421,10 +422,8 @@ export class AccesspageListComponent implements OnInit {
 
                 if(this.accessPages.length > 0 || this.nonAccessPages.length > 0) {
                     this.record[this.fieldName] = JSON.parse(JSON.stringify([this.accessPages, this.nonAccessPages]));
-                    postMessage[this.fieldName] = JSON.parse(JSON.stringify([...this.accessPages, ...this.nonAccessPages]));
+                    postMessage[this.fieldName] = JSON.parse(JSON.stringify(this.accessPages));
                 }
-
-                // let pm = postMessage.length > 0 ? postMessage : {};
 
                 this.mdupdsvc.update(this.fieldName, postMessage, undefined, this.FieldNameAPI).then((updateSuccess) => {
                     // console.log("###DBG  update sent; success: "+updateSuccess.toString());

--- a/oar-lps/libs/oarlps/src/lib/landing/references/ref-edit/ref-edit.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/references/ref-edit/ref-edit.component.ts
@@ -32,8 +32,9 @@ export class RefEditComponent implements OnInit {
     showRefData: boolean = false;
     showCitationData: boolean = false;
     showAllFields: boolean = false;
+    ref: Reference = {} as Reference;
 
-    @Input() ref: Reference = {} as Reference;
+    @Input() currentRef: Reference = {} as Reference;
     @Input() editMode: string = "edit";
     @Input() forceReset: boolean = false;
     @Output() dataChanged: EventEmitter<any> = new EventEmitter();
@@ -43,9 +44,11 @@ export class RefEditComponent implements OnInit {
 
     ngOnInit(): void {
         if(this.isEditing) this.showAllFields = true;
-        if(this.ref) this.originalRef = JSON.parse(JSON.stringify(this.ref));
-
-        this.reftype = this.ref.refType == "IsSupplementTo" ? "1" : "2" ;
+        if(this.currentRef) {
+            this.originalRef = JSON.parse(JSON.stringify(this.currentRef));
+            this.ref = JSON.parse(JSON.stringify(this.currentRef));
+            this.reftype = this.currentRef.refType == "IsSupplementTo" ? "1" : "2" ;
+        }
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -55,12 +58,14 @@ export class RefEditComponent implements OnInit {
             this.reset();
         }
 
-        if(changes.ref) {
-            if(this.ref) {
-                this.originalRef = JSON.parse(JSON.stringify(this.ref));
+        if(changes.currentRef) {
+            if(this.currentRef) {
+                this.originalRef = JSON.parse(JSON.stringify(this.currentRef));
+                this.ref = JSON.parse(JSON.stringify(this.currentRef));
                 this.reftype = this.originalRef.refType == "IsSupplementTo" ? "1" : "2" ;
             }else{
                 this.originalRef = undefined;
+                this.ref = {} as Reference;
             }
         }
     }

--- a/oar-lps/libs/oarlps/src/lib/landing/references/ref-list/ref-list.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/references/ref-list/ref-list.component.html
@@ -52,6 +52,6 @@
     </div>
     <!-- This is editing area. Will open up in add or edit mode -->
     <div style="overflow: hidden; width: 100%;" [@editExpand]="editBlockStatus">  
-        <lib-ref-edit [ref]="currentRef" [editMode]="editMode" [forceReset]="forceReset" (dataChanged)="onReferenceChange($event)"  (cmdOutput)="onCommandChanged($event)"></lib-ref-edit>
+        <lib-ref-edit [currentRef]="currentRef" [editMode]="editMode" [forceReset]="forceReset" (dataChanged)="onReferenceChange($event)"  (cmdOutput)="onCommandChanged($event)"></lib-ref-edit>
     </div>
 </div>


### PR DESCRIPTION
This check in fixed two bugs:

1. When there are data files and remove last access page, the app will crash.
2. After add reference to a blank record, undo will cause app to crash.

Adding topics cause app to crash in my local but it was ok in mdsdev. So I am not going to touch topics code.

Thanks.
Chuan