### PR TITLE
Fix Form Validation

### DIFF
--- a/pdr-rpa/pdr-rpa-request/src/app/app.component.html
+++ b/pdr-rpa/pdr-rpa-request/src/app/app.component.html
@@ -87,7 +87,7 @@
                                 Point of contact email is required.
                             </ng-container>
                             <ng-container *ngIf="requestForm.controls.email.errors.blacklisted">
-                                Point of contact email provided must be from your organization.
+                                Point of contact email is not allowed.
                             </ng-container>
                         </div>
                     </div>

--- a/pdr-rpa/pdr-rpa-request/src/app/app.component.spec.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/app.component.spec.ts
@@ -65,7 +65,7 @@ const mockCountries: Country[] = [
   { name: 'Mexico', code: 'MX' }
 ]
 
-const mockFormTemplate = { id: 'template1', disclaimers: [], agreements: [], blockedEmails: [], blockedCountries: [] };
+const mockFormTemplate = { id: 'template1', disclaimers: [], agreements: [], blockedEmails: ["@hotmail\\.", "@123\\."], blockedCountries: [] };
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -139,6 +139,26 @@ describe('AppComponent', () => {
     await component.loadCountries().toPromise();
     expect(mockConfigService.getCountries).toHaveBeenCalled();
     expect(component.countries).toEqual(countries);
+  });
+
+  it('should validate email against blacklisted patterns', () => {
+    component.setSelectedDataset('123');
+    fixture.detectChanges();
+  
+    const emailControl = component.requestForm.get('email');
+    
+    if (emailControl) {
+      emailControl.setValue('user@hotmail.com');
+      expect(emailControl.errors).toEqual({ blacklisted: 'pattern' });
+  
+      emailControl.setValue('user@123.com');
+      expect(emailControl.errors).toEqual({ blacklisted: 'pattern' });
+  
+      emailControl.setValue('user@safecompany.com');
+      expect(emailControl.errors).toBeNull();
+    } else {
+      fail('Email control is not defined');
+    }
   });
 
   // TODO: this test keeps failing as it doesn't recognize the recaptcha element.

--- a/pdr-rpa/pdr-rpa-request/src/app/app.component.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/app.component.ts
@@ -41,7 +41,7 @@ export class AppComponent {
         private messageService: MessageService,
         private configService: ConfigurationService,
         private rpaService: RPAService) {
-        this.initRequestForm();
+        // this.initRequestForm();
     }
 
     /**
@@ -55,7 +55,7 @@ export class AppComponent {
             // If 'ediid' is present, set the selected dataset using its value
             if (params['ediid']) {
                 this.queryId = params['ediid'];
-                this.setSelecetedDataset(this.queryId);
+                this.setSelectedDataset(this.queryId);
             }
             // Load countries list for use with dropdown menu
 
@@ -71,7 +71,7 @@ export class AppComponent {
    * Choose selectedDataset, and pick the appropriate form template from the config file
    * @param ediid the dataset ID
    */
-    setSelecetedDataset(ediid: string): void {
+    setSelectedDataset(ediid: string): void {
         this.getDatasets()
             // Start RxJs opeartors chaining
             .pipe(
@@ -90,11 +90,17 @@ export class AppComponent {
                             .subscribe((template) => {
                                 this.selectedFormTemplate = template;
                                 if (environment.debug) console.log(template);
+                                this.initRequestForm(template.blockedEmails);
+                                this.filterBlacklistedCountries(template.blockedCountries);
                             });
                     }
                 })
             )
             .subscribe((selectedDataset) => (this.selectedDataset = selectedDataset));
+    }
+
+    private filterBlacklistedCountries(blacklistedCountries: string[]): void {
+        this.countries = this.countries.filter(country => !blacklistedCountries.includes(country.name));
     }
 
     /**
@@ -374,13 +380,13 @@ export class AppComponent {
     /**
      * Initializes the request form with the necessary form controls and validators.
      */
-    private initRequestForm(): void {
+    private initRequestForm(blacklistedEmails: string[]): void {
 
         // let emailBlacklist = this.getEmailBlacklist();
-
+        console.log("blacklistedEmails", blacklistedEmails )
         this.requestForm = new FormGroup({
             fullName: new FormControl("", [Validators.required, Validators.minLength(2), Validators.maxLength(50), CustomValidators.nonLatinCharacters()]),
-            email: new FormControl("", [Validators.required, Validators.email]),
+            email: new FormControl("", [CustomValidators.blacklisted(blacklistedEmails), Validators.required, Validators.email]),
             phone: new FormControl("", [Validators.required]),
             organization: new FormControl("", [Validators.required]),
             address1: new FormControl("", [Validators.required]),

--- a/pdr-rpa/pdr-rpa-request/src/app/validators/custom-validators.spec.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/validators/custom-validators.spec.ts
@@ -80,9 +80,7 @@ describe('CustomValidators', () => {
 
   describe('blacklisted', () => {
     const blacklistedPatterns = ['test', '123'];
-    const blacklistedEmails = ['john.doe@example.com', 'jane.doe@example.com'];
-    const blacklistedDomains = ['example.com', 'test.com'];
-    const validatorFn = CustomValidators.blacklisted(blacklistedPatterns, blacklistedEmails, blacklistedDomains);
+    const validatorFn = CustomValidators.blacklisted(blacklistedPatterns);
 
     it('should return null for empty value', () => {
       const control = { value: '' } as AbstractControl;
@@ -90,7 +88,7 @@ describe('CustomValidators', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null for value that does not match any blacklisted pattern, email, or domain', () => {
+    it('should return null for value that does not match any blacklisted pattern', () => {
       const control = { value: 'hello.world@example.org' } as AbstractControl;
       const result = validatorFn(control);
       expect(result).toBeNull();
@@ -99,25 +97,19 @@ describe('CustomValidators', () => {
     it('should return error for value that matches a blacklisted pattern', () => {
       const control = { value: 'this is a test' } as AbstractControl;
       const result = validatorFn(control);
-      expect(result).toEqual({ blacklisted: true });
+      expect(result).toEqual({ blacklisted: 'pattern' });
     });
 
-    it('should return error for value that matches a blacklisted email', () => {
-      const control = { value: 'john.doe@example.com' } as AbstractControl;
+    it('should return error for value that contains a blacklisted pattern', () => {
+      const control = { value: 'abc123def' } as AbstractControl;
       const result = validatorFn(control);
-      expect(result).toEqual({ blacklisted: true });
+      expect(result).toEqual({ blacklisted: 'pattern' });
     });
 
-    it('should return error for value that matches a blacklisted domain', () => {
-      const control = { value: 'test@example.com' } as AbstractControl;
+    it('should return null for value that matches a substring not covered by a pattern', () => {
+      const control = { value: 'this is a safe string' } as AbstractControl;
       const result = validatorFn(control);
-      expect(result).toEqual({ blacklisted: true });
-    });
-
-    it('should return error for value that matches both a blacklisted email and domain', () => {
-      const control = { value: 'jane.doe@test.com' } as AbstractControl;
-      const result = validatorFn(control);
-      expect(result).toEqual({ blacklisted: true });
+      expect(result).toBeNull();
     });
   });
 });

--- a/pdr-rpa/pdr-rpa-request/src/app/validators/custom-validators.ts
+++ b/pdr-rpa/pdr-rpa-request/src/app/validators/custom-validators.ts
@@ -23,40 +23,22 @@ export class CustomValidators {
     }
 
     /**
-     * Validator that checks if the email is blacklisted based on patterns, email addresses, and domains.
+     * Validator that checks if the email is blacklisted based on patterns.
      * @param blacklistedPatterns - The array of blacklisted patterns.
-     * @param blacklistedEmails - The array of blacklisted email addresses.
-     * @param blacklistedDomains - The array of blacklisted email domains.
-     * @returns A validator function that returns an error if the email is blacklisted.
+     * @returns A validator function that returns an error if the email matches a blacklisted pattern.
      */
-    static blacklisted(
-        blacklistedPatterns: string[],
-        blacklistedEmails: string[],
-        blacklistedDomains: string[]
-    ): ValidatorFn {
+    static blacklisted(blacklistedPatterns: string[]): ValidatorFn {
         return (control: AbstractControl): ValidationErrors | null => {
             const email = control.value;
 
             if (email) {
                 // Check against blacklisted patterns
                 for (const pattern of blacklistedPatterns) {
-                    if (email.includes(pattern)) {
-                        // Return an error if the email contains a blacklisted pattern
-                        return { blacklisted: true };
+                    const regex = new RegExp(pattern);
+                    if (regex.test(email)) {
+                        // Return an error if the email matches a blacklisted pattern
+                        return { blacklisted: 'pattern' };
                     }
-                }
-
-                // Check against blacklisted emails
-                if (blacklistedEmails.includes(email)) {
-                    // Return an error if the email is blacklisted
-                    return { blacklisted: true };
-                }
-
-                // Check against blacklisted domains
-                const domain = email.substring(email.lastIndexOf('@') + 1);
-                if (blacklistedDomains.includes(domain)) {
-                    // Return an error if the email domain is blacklisted
-                    return { blacklisted: true };
                 }
             }
 

--- a/pdr-rpa/pdr-rpa-request/src/assets/datasets.yaml
+++ b/pdr-rpa/pdr-rpa-request/src/assets/datasets.yaml
@@ -183,5 +183,5 @@ formTemplates:
   agreements: 
     - I agree to the defined terms and conditions of this dataset.
     - I acknowledge that all requests are reviewed by a NIST employee or other individual acting on behalf of NIST. I represent that I have provided all requested information. I understand that if I have not provided all information I will not receive the dataset.
-  blockedEmails: []
-  blockedCountries: []
+  blockedEmails: ["@123\\.", "@126\\.", "@163\\.", "@aliyun\\.", "appleid\\.com$", "@aol\\.", "@closeli\\.", "@cwallet\\.dk$", "@email\\.com$", "@foxmail\\.", "@gmail\\.", "@hanmail\\.", "@hotmail\\.", "@icloud\\.", "@laposte\\.net$", "@live\\.", "@mac\\.", "@mail\\.ru$", "@mailinator\\.", "@me\\.", "@msn\\.", "@nate\\.", "@naver\\.", "@outlook\\.", "@qq\\.", "@sina\\.", "@yahoo\\.", "\\.cu$", "\\.ir$", "\\.kp$", "\\.sy$"]
+  blockedCountries: ["Cuba", "Iran, Islamic Republic of", "Korea, Democratic People's Republic of", "Syrian Arab Republic"]


### PR DESCRIPTION
This PR includes the following updates and improvements:

**Custom Validator Update:**

- Updated he **CustomValidators.blacklisted** method to only validate against email patterns.
- Removed checks for blacklisted emails and domains, using only pattern validation.

**Blacklisted Countries:**

- The country dropdown now filters out blacklisted countries.

**Testing:**
- Updated unit tests for the custom validator to match the current logic