### PR TITLE
Partially fix pdr-lps SSR: fix config loading and routing

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/config/config.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/config/config.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Inject, Optional } from "@angular/core";
+import { Injectable, Inject, Optional, PLATFORM_ID } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
+import { isPlatformServer } from '@angular/common';
 
 import { ConfigurationService } from 'oarng';
 import { ReleaseInfo, RELEASE_INFO, CONFIG_URL } from 'oarng';
@@ -12,14 +13,37 @@ import { LPSConfig } from './config.model';
 export class AppConfig extends ConfigurationService {
 
     constructor(http: HttpClient,
+                @Optional() @Inject(PLATFORM_ID) platid?: Object,
                 @Optional() @Inject(RELEASE_INFO) relInfo?: ReleaseInfo,
                 @Optional() @Inject(CONFIG_URL) configUrl?: string)
     {
         super(http, relInfo, configUrl);
+        if (platid)
+            this.isOnServer = isPlatformServer(platid);
+    }
+
+    protected _useServerSide(cfgdata : LPSConfig) {
+        cfgdata = deepCopy(cfgdata);
+        if (cfgdata['APIs'] && cfgdata['APIs']['serverSide']) {
+            cfgdata['APIs'] = { ...cfgdata['APIs'], ...cfgdata['APIs']['serverSide'] };
+            delete cfgdata['APIs']['serverSide'];
+        }
+        return cfgdata;
+    }
+
+    protected _hideServerSide(cfgdata : LPSConfig) {
+        cfgdata = deepCopy(cfgdata);
+        if (cfgdata['APIs'] && cfgdata['APIs']['serverSide'])
+            delete cfgdata['APIs']['serverSide'];
+        return cfgdata;
     }
 
     loadConfig(data: any): void {
         super.loadConfig(data);
+        if (this.isOnServer)
+            this.config = this._useServerSide(this.config as LPSConfig);
+        else
+            this.config = this._hideServerSide(this.config as LPSConfig);
         this.inferMissingValues();
     }
 

--- a/pdr-lps/angular.json
+++ b/pdr-lps/angular.json
@@ -158,7 +158,9 @@
     "pdr-lps-e2e": {
       "root": "e2e",
       "projectType": "application",
-      "cli": {},
+      "cli": {
+        "analytics": false
+      },
       "schematics": {},
       "architect": {
         "e2e": {
@@ -171,7 +173,9 @@
       }
     }
   },
-  "cli": {},
+  "cli": {
+    "analytics": false
+  },
   "schematics": {
     "@schematics/angular:class": {
       "skipTests": false

--- a/pdr-lps/src/app/app-routing.module.ts
+++ b/pdr-lps/src/app/app-routing.module.ts
@@ -33,11 +33,10 @@ const routes: Routes = [
     },
     // app paths
     { path: 'about',         component: LandingAboutComponent },
-    { path: 'od/id',
+    { path: 'lps',
       children: [
           { path: '',                component: NoidComponent          },
-          { path: ':id',             component: LandingPageComponent   },
-          { path: 'ark:/88434/:id',  component: LandingPageComponent   }
+          { path: '**',              component: LandingPageComponent   }
       ]
     },
     { path: 'nerdm',                 component: NerdmComponent         },

--- a/pdr-lps/src/app/app.component.ts
+++ b/pdr-lps/src/app/app.component.ts
@@ -33,7 +33,7 @@ export class AppComponent {
     }
 
     ngOnInit() {
-        this.appVersion = this.cfg.get("appVersion", "1.0") as string;
+        this.appVersion = this.cfg.get("systemVersion", "X.X") as string;
         this.homeButtonLink = this.cfg.get("links.portalBase", "") as string;
 
         if(this.inBrowser){

--- a/pdr-lps/src/app/app.server.module.ts
+++ b/pdr-lps/src/app/app.server.module.ts
@@ -5,6 +5,7 @@ import { ServerModule } from '@angular/platform-server';
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
 import { ServerMetadataTransferModule } from './nerdm/metadatatransfer-server.module';
+import { CONFIG_URL } from 'oarng';
 
 /**
  * The root module for the server-side application.  
@@ -23,5 +24,8 @@ import { ServerMetadataTransferModule } from './nerdm/metadatatransfer-server.mo
     // Since the bootstrapped component is not inherited from your
     // imported AppModule, it needs to be repeated here.
     bootstrap: [ AppComponent ],
+    providers: [
+        { provide: CONFIG_URL, useValue: "http://localhost:4000/assets/config.json" }
+    ]
 })
 export class AppServerModule {}

--- a/pdr-lps/src/app/landing/landingpage.component.ts
+++ b/pdr-lps/src/app/landing/landingpage.component.ts
@@ -233,7 +233,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         // Init the size of landing page body and the help box
         this.updateScreenSize();
 
-        this.reqId = this.route.snapshot.paramMap.get('id');
+        this.reqId = this.requestedIDfromRoute(this.route).replace('ark:/88434/', '');
         this.inBrowser = isPlatformBrowser(platformId);
         this.editMode = this.EDIT_MODES.VIEWONLY_MODE;
         this.delayTimeForMetricsRefresh = +this.cfg.get("delayTimeForMetricsRefresh", "300");
@@ -283,6 +283,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         setTimeout(() => {
             // this.displayBanner = true;
         }, 0);
+    }
+
+    protected requestedIDfromRoute(route : ActivatedRoute) : string {
+        return route.snapshot.url.map(u => u.toString()).join('/');
     }
 
     /**

--- a/pdr-lps/src/assets/config.json
+++ b/pdr-lps/src/assets/config.json
@@ -9,26 +9,17 @@
     "PDRAPIs": {
         "mdSearch": "https://data.nist.gov/rmm/records/",
         "mdService": "https://data.nist.gov/od/id/",
-        "metrics": "https://data.nist.gov/rmm/usagemetrics/"
-    },
-    "auth": {
-        "serviceEndpoint": "https://data.nist.gov/sso/"
-    },
-    "dapEditing": {
-        "serviceEndpoint": "https://mdsdev.nist.gov/midas/dap/mds3/",
-        "editEnabled": false
-    },
-    "staffdir": {
-        "serviceEndpoint": "http://data.nist.gov:9092/oar1"
+        "metrics": "https://data.nist.gov/rmm/usagemetrics/",
+        "serverSide": { 
+            "mdService": "https://data.nist.gov/od/id/"
+        }
     },
     "mode": "dev",
     "systemVersion": "v1.3.X",
     "production": false,
-    "distService": "https://data.nist.gov/od/ds/",
     "gaCode": "not-set",
     "screenSizeBreakPoint": 1200,
     "bundleSizeAlert": 500000000,
     "downloadableFileLimit": 300,
-    "delayTimeForMetricsRefresh": 300,
-    "standardNISTTaxonomyURI": "https://data.nist.gov/od/dm/nist-themes/"
+    "delayTimeForMetricsRefresh": 300
 }


### PR DESCRIPTION
 This PR begins to address fixing SSR support for the new pdr-lps app (replacing the same in oar-pdr).  It addresses the following:
   * It ensures the the server side can properly load the configuration file.  In particular, the URL for loading it on the server side is changed from its default in `app.server.module.ts`.  (Note that changes were also necessary to the `oar-docker` entrypoint script to write the configuration to the right location.
   * It aligns the the routing with that used by `oar-pdr` (`od/id` => `lps`)

Further debugging is needed to get the app working completely.  I recommend running SSR standalone using `npm run start-pdrlps:ssr` (after building).  