### PR TITLE
Fixed copy to clipboard display for rclone command.

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/bulk-download/bulk-download.component.html
+++ b/oar-lps/libs/oarlps/src/lib/bulk-download/bulk-download.component.html
@@ -99,7 +99,7 @@
                 </span>
                 <span 
                     id="copy-to-clipboard" 
-                    (click)="copyToClipboard(rcloneCommand, 'preview')" 
+                    (click)="copyToClipboard(rcloneCommand, 'rclone')" 
                     data-toggle="tooltip" 
                     title="Copy to clipboard">
                     <i class="faa faa-clone" style="color: rgb(1, 90, 255);cursor: pointer;"></i>

--- a/oar-lps/libs/oarlps/src/lib/bulk-download/bulk-download.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/bulk-download/bulk-download.component.ts
@@ -91,6 +91,12 @@ export class BulkDownloadComponent implements OnInit {
         document.body.removeChild(selBox);
 
         switch (command) {
+            case ("rclone"): 
+                this.rcloneCopied = true;
+                setTimeout(() => {
+                    this.rcloneCopied = false;
+                }, 2000);
+                break;            
             case ("preview"): 
                 this.previewCopied = true;
                 setTimeout(() => {


### PR DESCRIPTION
Issue: when clicked on the copy icon next to "rclone copy :http: ./mds2-3408/ --http-url http://data.nist.gov/od/ds/mds2-3408/ -P", the line "python pdrdownload.py -I mds2-3408" was highlighted.