### PR TITLE
Fixed version history that caused the page failed to load. Also changed config "locations" to "links".

### DIFF
--- a/midas-author/lps/src/app/app.component.ts
+++ b/midas-author/lps/src/app/app.component.ts
@@ -108,7 +108,7 @@ export class AppComponent {
         if(this.inBrowser){
             this.gaCode = this.cfg.get("gaCode", "") as string;
             this.ga4Code = this.cfg.get("ga4Code", "") as string;
-            let homeurl = this.cfg.get("locations.portalBase", "data.nist.gov") as string;
+            let homeurl = this.cfg.get("links.portalBase", "data.nist.gov") as string;
 
             const url = new URL("https://" + homeurl);
             this.hostName = url.hostname;

--- a/midas-author/wizard/src/app/app.component.ts
+++ b/midas-author/wizard/src/app/app.component.ts
@@ -53,7 +53,7 @@ export class AppComponent {
         if(this.inBrowser){
             this.gaCode = this.cfg.get("gaCode", "") as string;
             this.ga4Code = this.cfg.get("ga4Code", "") as string;
-            let homeurl = this.cfg.get("locations.portalBase", "data.nist.gov") as string;
+            let homeurl = this.cfg.get("links.portalBase", "data.nist.gov") as string;
 
             const url = new URL("https://" + homeurl);
             this.hostName = url.hostname;

--- a/oar-lps/libs/oarlps/src/lib/datacart/cart.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/datacart/cart.service.ts
@@ -32,7 +32,7 @@ export class CartService {
                 throw new Error("PDRAPIs.rpaBackend endpoint not configured!");
     
             if (! this.rpaBackend.endsWith("/")) this.rpaBackend += "/"
-            this.portalBase = cfg.get("locations.portalBase", "/unconfigured");
+            this.portalBase = cfg.get("links.portalBase", "/unconfigured");
     }
 
     /**

--- a/oar-lps/libs/oarlps/src/lib/landing/ispartof/ispartof.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/ispartof/ispartof.component.ts
@@ -63,7 +63,7 @@ export class IspartofComponent implements OnInit {
            
             this.isPartOf = [
                 article,
-                // this.cfg.get("locations.landingPageService") + coll['@id'],
+                // this.cfg.get("links.landingPageService") + coll['@id'],
                 this.landingPageServiceStr + coll['@id'],
                 title,
                 suffix

--- a/oar-lps/libs/oarlps/src/lib/landing/version/version.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/version/version.component.ts
@@ -157,7 +157,7 @@ export class VersionComponent implements OnChanges {
         }
 
         // look at the version history to see if there is a newer version listed
-        if (this.record['version'] && this.record['versionHistory']) {
+        if (this.record['version'] && this.record['versionHistory'] && this.record['versionHistory'].length > 0) {
             let history = this.record['versionHistory'];
             history.sort(compare_histories);
 

--- a/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.ts
@@ -121,7 +121,7 @@ export class MetricsComponent implements OnInit {
         }
 
     ngOnInit() {
-        this.lps = this.cfg.get("locations.landingPageService", "/od/id/");
+        this.lps = this.cfg.get("links.landingPageService", "/od/id/");
 
         this.detectScreenSize();
         this.recordLevelData = new RecordLevelMetrics();

--- a/pdr-lps/src/app/app.component.ts
+++ b/pdr-lps/src/app/app.component.ts
@@ -44,7 +44,6 @@ export class AppComponent {
     }
 
     ngOnInit() {
-        console.log("cfg", this.cfg);
         this.appVersion = this.cfg.get("systemVersion", "X.X") as string;
         this.homeButtonLink = this.cfg.get("links.portalBase", "") as string;
         this.contactLink = this.cfg.get("links.pdrSearch", "/sdp/") + "#/help/contactus";
@@ -65,7 +64,7 @@ export class AppComponent {
         if(this.inBrowser){
             this.gaCode = this.cfg.get("gaCode", "") as string;
             this.ga4Code = this.cfg.get("ga4Code", "") as string;
-            let homeurl = this.cfg.get("locations.portalBase", "data.nist.gov") as string;
+            let homeurl = this.cfg.get("links.portalBase", "data.nist.gov") as string;
 
             const url = new URL("https://" + homeurl);
             this.hostName = url.hostname;


### PR DESCRIPTION
The empty version history array caused the page failed to load. Adding a guard to skip the empty array fixed the problem.
Also removed the console log that print the config.
Also changed all "locations." to "links.". This was fixed in oar-pdr-angular-18-config02. 