### PR TITLE
midas-author-lps: fix Refresh Files button

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,0 @@
-oar-pdr-angular feature/fontawesome-update-991b2d5e

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.html
@@ -13,7 +13,7 @@
                         type="submit" 
                         class="p-button-sm light-blue-btn" 
                         id="btn-fm" 
-                        (click)="refreshFiles()" 
+                        (click)="reloadFiles()" 
                         label="Refresh Files" 
                         [icon]="refreshFilesIcon" 
                         iconPos="left" 

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.html
@@ -13,7 +13,7 @@
                         type="submit" 
                         class="p-button-sm light-blue-btn" 
                         id="btn-fm" 
-                        (click)="reloadFiles()" 
+                        (click)="refreshFiles()" 
                         label="Refresh Files" 
                         [icon]="refreshFilesIcon" 
                         iconPos="left" 

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.ts
@@ -228,55 +228,40 @@ export class DatafilesMidasComponent {
         // }     
     }
 
-    refreshFiles() {
-        this.refreshFilesIcon = "faa faa-spinner faa-spin icon-white";
-        this.mdupdsvc.syncDataFiles().subscribe(
-            fsdata => {
-                this.reloadFiles();
-                this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
-            },
-            err => {
-                console.error("Failed to trigger file sync: ", err);
-                this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
-            }
-        );
-    }
-
     /**
      * Reload data files
      */
     reloadFiles() {
-        this.mdupdsvc.loadDataFiles().subscribe( data => {
-            this.mdupdsvc.loadDraft(true).subscribe({
-                next: (md) => 
-                {
-                    if(md)
-                    {
-                        this.mdupdsvc.cacheMetadata(md as NerdmRes);
-                        this.mdupdsvc.checkUpdatedFields(md as NerdmRes);
+        this.refreshFilesIcon = "faa faa-spinner faa-spin icon-white";
+        this.mdupdsvc.syncDataFiles().subscribe({
+            next: (fsdata) => {
+                this.mdupdsvc.loadDraft(true).subscribe({
+                    next: (md) => {
+                        if(md) {
+                            this.mdupdsvc.cacheMetadata(md as NerdmRes);
+                            this.mdupdsvc.checkUpdatedFields(md as NerdmRes);
 
-                        if (md['components']) 
-                            this.record['components'] = JSON.parse(JSON.stringify(md['components']));
-                        else
-                            this.record['components'] = []
+                            if (md['components']) 
+                                this.record['components'] = JSON.parse(JSON.stringify(md['components']));
+                            else
+                                this.record['components'] = []
                         
-                        // this.buildTree(this.record['components']); // Will rebuild in pub component
-                    }else{
-                        this.msgsvc.error("Fail to retrive updated dataset.");
+                            // this.buildTree(this.record['components']); // Will rebuild in pub component
+                        }else{
+                            this.msgsvc.error("Fail to retrive updated dataset.");
+                        }
+                        this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
+                    },
+                    error: (err) => {
+                        console.error("Failed to pull updated record: ", err);
+                        this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
                     }
-                }
-                // error: (err) => 
-                // {
-                //     if(err.statusCode == 404)
-                //     {
-                //         console.error("404 error.");
-                //         this.mdupdsvc.resetOriginal();
-                //         this.msgsvc.error(err.message);
-                //     }
-
-                //     this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
-                // }
-            });
+                });
+            },
+            error: (err) => {
+                console.error("Failed to trigger file sync: ", err);
+                this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
+            }
         });
     }
 

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-midas/datafiles-midas.component.ts
@@ -228,11 +228,24 @@ export class DatafilesMidasComponent {
         // }     
     }
 
+    refreshFiles() {
+        this.refreshFilesIcon = "faa faa-spinner faa-spin icon-white";
+        this.mdupdsvc.syncDataFiles().subscribe(
+            fsdata => {
+                this.reloadFiles();
+                this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
+            },
+            err => {
+                console.error("Failed to trigger file sync: ", err);
+                this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
+            }
+        );
+    }
+
     /**
      * Reload data files
      */
     reloadFiles() {
-        this.refreshFilesIcon = "faa faa-spinner faa-spin icon-white";
         this.mdupdsvc.loadDataFiles().subscribe( data => {
             this.mdupdsvc.loadDraft(true).subscribe({
                 next: (md) => 
@@ -251,8 +264,6 @@ export class DatafilesMidasComponent {
                     }else{
                         this.msgsvc.error("Fail to retrive updated dataset.");
                     }
-
-                    this.refreshFilesIcon = "faa faa-repeat fa-1x icon-white";
                 }
                 // error: (err) => 
                 // {

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/metadataupdate.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/metadataupdate.service.ts
@@ -806,6 +806,18 @@ export class MetadataUpdateService {
     }
 
     /**
+     * sync the file metadata with the contents of the file space and return the 
+     * file space summary information.
+     */
+    public syncDataFiles() : Observable<Object> {
+        if (!this.dapUpdtSvc) {
+            console.error("Attempted to update without authorization!  Ignoring update.");
+            return of({});
+        }
+        return this.dapUpdtSvc.syncFiles();
+    }
+
+    /**
      * load files from the file manager.
      */
     public loadDataFiles(onSuccess?: () => void): Observable<Object> {
@@ -813,7 +825,7 @@ export class MetadataUpdateService {
             console.error("Attempted to update without authorization!  Ignoring update.");
             return of({});
         }
-        return this.dapUpdtSvc.getDataSubset("pdr:files").pipe(
+        return this.dapUpdtSvc.getDataSubset("pdr:f").pipe(
             tap((res) => {
                 if (onSuccess) onSuccess();
             }),

--- a/oar-lps/libs/oarlps/src/lib/nerdm/dap.service.spec.ts
+++ b/oar-lps/libs/oarlps/src/lib/nerdm/dap.service.spec.ts
@@ -192,6 +192,14 @@ describe('LocalDAPService/LocalDAPUpdateService', function() {
         expect(dap.getRecord().name).toEqual("gurn");
     });
 
+    it("syncFiles", async () => {
+        let dap: dapsvc.DAPUpdateService = await svc.create("goober").toPromise();
+        expect(dap.name).toEqual("goober");
+        let filespace: Object = await dap.syncFiles().toPromise();
+        expect(filespace).toEqual({"action": "sync"});
+        expect(filespace['action']).toEqual("sync");
+    });
+
 });
 
 describe("MIDASDAPService/MIDASDAPUpdateService", function() {
@@ -472,5 +480,23 @@ describe("MIDASDAPService/MIDASDAPUpdateService", function() {
         expect(dap.getRecord().name).toEqual("gurn");
     });
     
+    it("syncFiles", async () => {
+        let pc = svc.create("goober").toPromise();
+        let req = httpmock.expectOne(ep);
+        expect(req.request.method).toBe('POST');
+        req.flush(newrec("goober"));
+        let dap: dapsvc.DAPUpdateService = await pc;
+
+        expect(dap.getRecord().name).toEqual("goober");
+        expect(dap.name).toEqual("goober");
+
+        let p = dap.syncFiles().toPromise();
+        req = httpmock.expectOne(ep+"/mds3:0001/file_space");
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.body).toEqual({"action": "sync", "full": true});
+        req.flush({"action": "sync", "full": true});
+        expect(await p).toEqual({"action": "sync", "full": true});
+    });
+
 
 });


### PR DESCRIPTION
The "Refresh Files" button on the editable landing page is supposed to update the file listing to correspond to the files currently in the file space's uploads folder; however, clicking on this button was not doing so despite the presence of files.   This was because the implementation was only retrieving the list of files without first requesting that the backend  synchronize its data with the file manager.  This PR fixes this by adding the needed sync call before retrieving the files.  

This included adding a new method to the `DAPUpdateService`: `syncFiles()` which will send the sync request to the backend.  A similar function, `syncDataFiles()`, was added to the `MetadataUpdateService` class which passes such a request from the displaying component onto `DAPUpdateService`.  

There may currently be a superfluous call to retrieve just the file listing; if this indeed is not needed, this PR can be simplified a bit.  I will consult with @chuanlin2018.  