### PR TITLE
Fix/submission03

### DIFF
--- a/midas-author/lps/src/app/app.component.html
+++ b/midas-author/lps/src/app/app.component.html
@@ -17,6 +17,6 @@
 </app-header>
 
 <div style="min-height: 58%;">
-  <router-outlet></router-outlet>
+    <router-outlet></router-outlet>
 </div>
 <app-footer></app-footer>

--- a/midas-author/lps/src/app/app.module.ts
+++ b/midas-author/lps/src/app/app.module.ts
@@ -13,12 +13,15 @@ import { StaffDirModule } from 'oarng';
 import { DefaultUrlSerializer, UrlTree, UrlSerializer } from '@angular/router';
 import { FooterComponent, HeaderComponent, HeaderPubComponent } from 'oarng';
 import { OARLPSModule, ConfigModule, EditControlModule, CollectionService, ConfirmationDialogService,
-         GoogleAnalyticsService, ErrorsModule, AppErrorHandler, LandingAboutComponent
+    GoogleAnalyticsService, ErrorsModule, AppErrorHandler, LandingAboutComponent,
+    SpinnerInterceptor
 } from 'oarlps';
 import { ToastrModule } from 'ngx-toastr';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
+import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 export class LowerCaseUrlSerializer extends DefaultUrlSerializer {
   parse(url: string): UrlTree {
@@ -74,7 +77,9 @@ enableProdMode();
         DatePipe,
         CollectionService,
         NgbActiveModal,
-        ConfirmationDialogService
+        ConfirmationDialogService,
+        { provide: HTTP_INTERCEPTORS, useClass: SpinnerInterceptor, multi: true },
+        fakeBackendProvider
         // {
         //     provide: APP_INITIALIZER,
         //     useFactory: initializeApp,

--- a/midas-author/lps/src/app/app.module.ts
+++ b/midas-author/lps/src/app/app.module.ts
@@ -20,7 +20,6 @@ import { ToastrModule } from 'ngx-toastr';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule } from '@angular/common';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { fakeBackendProvider } from './_helpers/fakeBackendInterceptor';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 export class LowerCaseUrlSerializer extends DefaultUrlSerializer {
@@ -78,8 +77,7 @@ enableProdMode();
         CollectionService,
         NgbActiveModal,
         ConfirmationDialogService,
-        { provide: HTTP_INTERCEPTORS, useClass: SpinnerInterceptor, multi: true },
-        fakeBackendProvider
+        { provide: HTTP_INTERCEPTORS, useClass: SpinnerInterceptor, multi: true }
         // {
         //     provide: APP_INITIALIZER,
         //     useFactory: initializeApp,

--- a/midas-author/lps/src/app/landing/landingpage.component.html
+++ b/midas-author/lps/src/app/landing/landingpage.component.html
@@ -142,10 +142,10 @@
 
 <!-- Show spinner -->
 <div *ngIf="!_showContent">
-    <pdr-done [message]="loadingMessage"></pdr-done>
+    <pdr-msg-page [message]="loadingMessage"></pdr-msg-page>
 </div>
 
 <!-- Display done page -->
 <div [ngStyle]="{'display': displaySpecialMessage? 'block' : 'none'}">
-    <pdr-done [message]='message'></pdr-done>
+    <pdr-msg-page [message]='message'></pdr-msg-page>
 </div>

--- a/midas-author/lps/src/app/landing/landingpage.component.ts
+++ b/midas-author/lps/src/app/landing/landingpage.component.ts
@@ -379,8 +379,8 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
      * the Angular rendering infrastructure.
      */
     ngOnInit() {
-      this.landingPageURL = this.cfg.get('links.pdrIDResolver','/od/id/');
-      this.landingPageServiceStr = this.cfg.get('links.pdrIDResolver','https://data.nist.gov/od/id/');
+        this.landingPageURL = this.cfg.get('links.pdrIDResolver','/od/id/');
+        this.landingPageServiceStr = this.cfg.get('links.pdrIDResolver','https://data.nist.gov/od/id/');
         this.helpWidthRatio = this.helpWidth / window.innerWidth;
 
         this.landingPageURL = this.cfg.get('PDRAPIs.mdService','/od/id/');
@@ -416,8 +416,11 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 // Use parameter "editEnabled". Need to decide the edit mode when backend is ready.
                 // For now, always go to edit mode.
                 // let param = queryParams.get("editmode");
-                    let param = queryParams.get("editenabled");
+                let param = queryParams.get("editenabled");
+                if(param)
                     this.paramEditEnabled = param.toLocaleLowerCase() == 'true';
+                else
+                    this.paramEditEnabled = false;
 
             });
 
@@ -427,60 +430,62 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             if(this.authsvc.isAuthenticated) {
                 this.globalService.setAuthenticated(true);
                 this.mdupdsvc.startEditing(this.reqId).subscribe({
-                next: (success) => {
-                    this.theme = ThemesPrefs.getTheme((new NERDResource(this.md)).theme());
+                    next: (success) => {
+                        this.theme = ThemesPrefs.getTheme((new NERDResource(this.md)).theme());
 
-                    if(this.inBrowser){
-                        if(this.cfg_editEnabled){
-                            this.metricsData.hasCurrentMetrics = false;
-                            this.showMetrics = true;
-                        }else{
-                            if(this.theme == Themes.DEFAULT_THEME){
-                                this.getMetrics();
+                        if(this.inBrowser){
+                            if(this.cfg_editEnabled){
+                                this.metricsData.hasCurrentMetrics = false;
+                                this.showMetrics = true;
+                            }else{
+                                if(this.theme == Themes.DEFAULT_THEME){
+                                    this.getMetrics();
+                                }
+
+                            }
+                        }
+
+                        // proceed with rendering of the component
+                        this.useMetadata();
+
+                        let showError: boolean;
+                        // if editing is enabled, and "editEnabled=true" is in URL parameter, try to start the page
+                        // in editing mode.  This is done in concert with the authentication process that can involve
+                        // redirection to an authentication server; on successful authentication, the server can
+                        // redirect the browser back to this landing page with editing turned on.
+                        if (this.inBrowser) {
+                            this.edstatsvc.setShowLPContent(true);
+
+                                if (this.editRequested) {
+                                    showError = false;
+                                    // Need to pass reqID (resID) because the resID in editControlComponent
+                                    // has not been set yet and the startEditing function relies on it.
+                                    this.edstatsvc.startEditing(this.reqId);
+                                }
+                                else
+                                    showError = true;
+                            }
+                            //Display error if any
+                            if(showError) {
+
                             }
 
-                        }
+                            this.mdupdsvc.loadDBIOrecord().subscribe({
+                                next: (dbio) => {
+                                    // console.log("dbio", dbio)
+                                },
+                                error: (err) => {
+                                    console.error(err);
+                                }
+                            });
+
+                    },
+                    error: (err) => {
+                        this.globalService.setAuthorized(false);
+                        console.log("Load error", err);
+                        this.loadingMessage = "Failed to load data for editing. " + err.message;
                     }
-
-                    // proceed with rendering of the component
-                    this.useMetadata();
-
-                    let showError: boolean;
-                    // if editing is enabled, and "editEnabled=true" is in URL parameter, try to start the page
-                    // in editing mode.  This is done in concert with the authentication process that can involve
-                    // redirection to an authentication server; on successful authentication, the server can
-                    // redirect the browser back to this landing page with editing turned on.
-                    if (this.inBrowser) {
-                        this.edstatsvc.setShowLPContent(true);
-
-                            if (this.editRequested) {
-                                showError = false;
-                                // Need to pass reqID (resID) because the resID in editControlComponent
-                                // has not been set yet and the startEditing function relies on it.
-                                this.edstatsvc.startEditing(this.reqId);
-                            }
-                            else
-                                showError = true;
-                        }
-                        //Display error if any
-                        if(showError) {
-
-                        }
-
-                        this.mdupdsvc.loadDBIOrecord().subscribe({
-                            next: (dbio) => {
-                                // console.log("dbio", dbio)
-                            },
-                            error: (err) => {
-                                console.error(err);
-                            }
-                        });
-
-                },
-                error: (err) => {
-                    this.globalService.setAuthorized(false);
-                    console.log("Load error", err);
-                }})
+                })
             }else{
                 //Not authenticated:
                 this.globalService.setAuthenticated(false);
@@ -492,12 +497,12 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     }
 
     displayOnly() {
-      this._showContent = false;
-      this.editRequested = false;
-      this.loadPublicData();
-      this.isPublicSite = true;
-      this.edstatsvc.setShowLPContent(true);
-      this._showContent = true;
+        this._showContent = false;
+        this.editRequested = false;
+        this.loadPublicData();
+        this.isPublicSite = true;
+        this.edstatsvc.setShowLPContent(true);
+        this._showContent = true;
     }
 
     /**
@@ -563,7 +568,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
               if (metadataError == "not-found") {
                   if (this.editRequested) {
                       console.log("ID not found...");
-                      this.edstatsvc._setEditMode(this.EDIT_MODES.OUTSIDE_MIDAS_MODE);
+                      this.edstatsvc.setEditMode(this.EDIT_MODES.OUTSIDE_MIDAS_MODE);
                       this.setMessage();
                       this.displaySpecialMessage = true;
                   }
@@ -583,8 +588,9 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
           }
           else {
               metadataError = "int-error";
-              // this.router.navigateByUrl("int-error/" + this.reqId, { skipLocationChange: true });
-              this.router.navigateByUrl("int-error/" + this.reqId, { skipLocationChange: true });
+              //   this.router.navigateByUrl("int-error/" + this.reqId, { skipLocationChange: true });
+              this.message = "Public data not available for this record.";
+              this.displaySpecialMessage = true;
           }
       });
     }
@@ -895,22 +901,22 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
                 if (result) {
                     // Check revision mode
                     if (this.mdupdsvc.published) {
-                        this.edstatsvc._setEditType(this.editTypes.REVISE);
+                        this.edstatsvc.setEditType(this.editTypes.REVISE);
                         // this.edstatsvc.setReviseType(this.arrRevisionTypes[0]["type"]);
-                        this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE);
+                        this.edstatsvc.setEditMode(this.EDIT_MODES.PREVIEW_MODE);
                     } else if (this.mdupdsvc.submitted) {
-                        this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE);
+                        this.edstatsvc.setEditMode(this.EDIT_MODES.PREVIEW_MODE);
                     } else {
                         this.editRequested = true;
                         // this.isEditMode = true;
-                        this.edstatsvc._setEditMode(this.EDIT_MODES.EDIT_MODE);
-                        this.edstatsvc.editMode.set(this.EDIT_MODES.EDIT_MODE);
-                        this.edstatsvc._setEditType(this.editTypes.NORMAL);
+                        this.edstatsvc.setEditMode(this.EDIT_MODES.EDIT_MODE);
+                        // this.edstatsvc.editMode.set(this.EDIT_MODES.EDIT_MODE);
+                        this.edstatsvc.setEditType(this.editTypes.NORMAL);
                     }
                 }
                 else {
                     this.editRequested = false;
-                    this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE);
+                    this.edstatsvc.setEditMode(this.EDIT_MODES.PREVIEW_MODE);
                     // this._showContent = true;
                     // this.edstatsvc.setShowLPContent(true);
                 }
@@ -920,10 +926,11 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
             });
         }else{
             this.editRequested = false;
-            this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE);
+            this.edstatsvc.setEditMode(this.EDIT_MODES.VIEWONLY_MODE);
             this.edstatsvc.setShowLPContent(true);
             this._showContent = true;
             this.globalService.setAuthorized(false);
+            this.showData();
         }
 
         //For fakebackend use

--- a/midas-author/wizard/src/app/app.component.html
+++ b/midas-author/wizard/src/app/app.component.html
@@ -8,6 +8,7 @@
         </div>
 
         <div class="wiz-page-container">
+            <app-spinner></app-spinner>
             <router-outlet></router-outlet>
         </div>
 

--- a/midas-author/wizard/src/app/app.module.ts
+++ b/midas-author/wizard/src/app/app.module.ts
@@ -12,12 +12,13 @@ import { RELEASE } from '../environments/release-info';
 import { InputTextModule } from "primeng/inputtext";
 import { HttpClientModule } from '@angular/common/http';
 import { ConfigModule, MetadataUpdateService } from 'oarlps';
-import { GoogleAnalyticsService, SidebarService } from "oarlps";
+import { GoogleAnalyticsService, SidebarService, SpinnerInterceptor, SpinnerComponent } from "oarlps";
 import { ToastrModule } from 'ngx-toastr';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FooterComponent, HeaderComponent } from 'oarng';
 import { PeopleComponent } from 'oarlps';
 import { SDSuggestion, SDSIndex, StaffDirectoryService, AuthenticationService } from 'oarng';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 @NgModule({
     declarations: [
@@ -41,15 +42,16 @@ import { SDSuggestion, SDSIndex, StaffDirectoryService, AuthenticationService } 
         }),
         FooterComponent,
         HeaderComponent,
-        PeopleComponent
+        PeopleComponent,
+        SpinnerComponent
     ],
     providers: [
         { provide: RELEASE_INFO, useValue: RELEASE },
         GoogleAnalyticsService,
         MetadataUpdateService,
         SidebarService,
-        StaffDirectoryService
-        // fakeBackendProvider
+        StaffDirectoryService,
+        { provide: HTTP_INTERCEPTORS, useClass: SpinnerInterceptor, multi: true }
     ],
     schemas: [CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA],
     bootstrap: [AppComponent]

--- a/oar-lps/libs/oarlps/src/lib/landing/done/done.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/done/done.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 @Component({
-  selector: 'pdr-done',
+  selector: 'pdr-msg-page',
   templateUrl: './done.component.html',
   styleUrls: ['./done.component.css']
 })

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editcontrol.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editcontrol.component.ts
@@ -167,18 +167,18 @@ export class EditControlComponent implements OnInit, OnChanges {
                 if (md && md != this.mdrec) {
                     if(md && !md["keyword"]) md["keyword"] = [];
                     this.mdrec = md as NerdmRes;
-                    this.edstatsvc._setLastUpdated(this.mdupdsvc.lastUpdate);
+                    this.edstatsvc.setLastUpdated(this.mdupdsvc.lastUpdate);
                     // this.mdrecChange.emit(md as NerdmRes);
                 }
             }
         );
 
-        this.edstatsvc._setLastUpdated(this.mdupdsvc.lastUpdate);
-        this.edstatsvc._setAuthorized(this.isAuthorized());
+        this.edstatsvc.setLastUpdated(this.mdupdsvc.lastUpdate);
+        this.edstatsvc.setAuthorized(this.isAuthorized());
 
         this.authsvc.getCredentials().subscribe((cred) => {
             this.cred = cred;
-            this.edstatsvc._setUserID(this.cred.userID);
+            this.edstatsvc.setUserID(this.cred.userID);
         })
 
         //Load suggestions:
@@ -202,7 +202,7 @@ export class EditControlComponent implements OnInit, OnChanges {
         // set edit mode to view only on init
         // this.setEditMode(this.EDIT_MODES.VIEWONLY_MODE);
         this.ngOnChanges();
-        this.edstatsvc._watchRemoteStart((remoteObj) => {
+        this.edstatsvc.watchRemoteStart((remoteObj) => {
             // To remote start editing, resID need be set otherwise authorizeEditing()
             // will do nothing and the app won't change to edit mode
             if (remoteObj.resID) {
@@ -215,7 +215,7 @@ export class EditControlComponent implements OnInit, OnChanges {
             if (fileManagerUrl) {
                 this.fileManagerUrl = fileManagerUrl;
             }
-        });     
+        });
         
         this.edstatsvc.watchEditMode((editMode) => {
             this._editMode = editMode;
@@ -448,8 +448,8 @@ export class EditControlComponent implements OnInit, OnChanges {
     setEditMode(editmode : string){
         this._editMode = editmode;
         //broadcast the editmode
-        this.edstatsvc.editMode.set(editmode);
-        this.edstatsvc._setEditMode(editmode);
+        // this.edstatsvc.editMode.set(editmode);
+        this.edstatsvc.setEditMode(editmode);
         this.chref.detectChanges();
     }
 
@@ -568,7 +568,7 @@ export class EditControlComponent implements OnInit, OnChanges {
 
                     //See if this is revision
                     if (this.mdupdsvc.published && !this.revisionStarted) {
-                        this.edstatsvc._setEditType(this.editTypes.REVISE);
+                        this.edstatsvc.setEditType(this.editTypes.REVISE);
                         // this.edstatsvc.setReviseType(this.arrRevisionTypes[0]["typeName"]);
                         this.setEditMode(this.EDIT_MODES.PREVIEW_MODE);
                     } else if (this.mdupdsvc.submitted) {
@@ -771,12 +771,12 @@ export class EditControlComponent implements OnInit, OnChanges {
 
                     if(authenticated){
                       subscriber.next(Boolean(this._dapUpdtsvc));
-                      this.edstatsvc._setUserID(this.mdupdsvc.authsvc.userID);
-                      this.edstatsvc._setAuthorized(true);
+                      this.edstatsvc.setUserID(this.mdupdsvc.authsvc.userID);
+                      this.edstatsvc.setAuthorized(true);
                     }else{
                       subscriber.next(false);
-                      this.edstatsvc._setAuthorized(false);
-                      this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE)
+                      this.edstatsvc.setAuthorized(false);
+                      this.edstatsvc.setEditMode(this.EDIT_MODES.PREVIEW_MODE)
                     }
                     
                     subscriber.complete();
@@ -789,8 +789,8 @@ export class EditControlComponent implements OnInit, OnChanges {
                     this.msgsvc.syserror(msg);
                     subscriber.next(false);
                     subscriber.complete();
-                    this.edstatsvc._setAuthorized(false);
-                    this.edstatsvc._setEditMode(this.EDIT_MODES.PREVIEW_MODE)
+                    this.edstatsvc.setAuthorized(false);
+                    this.edstatsvc.setEditMode(this.EDIT_MODES.PREVIEW_MODE)
                 }
             );
         });

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.component.html
@@ -8,6 +8,11 @@
     </span>
 
     <span class="badge">
-        {{action}}
+        @if(loading){
+            <app-spinner [local]="true"></app-spinner>
+        }
+        @else{
+            {{action}}
+        }
     </span>
 </div>

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.component.ts
@@ -9,6 +9,10 @@ import { LandingpageService } from '../landingpage.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DatePipe } from '@angular/common';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { SpinnerComponent } from '../../shared/spinner/spinner.component';
+import { SpinnerInterceptor } from '../../shared/spinner/spinner-interceptor';
+import { SpinnerService } from '../../shared/spinner/spinner.service';
 
 /**
  * A panel inside the EditControlComponent that displays information about the status of 
@@ -26,6 +30,10 @@ import { DatePipe } from '@angular/common';
     imports: [
         CommonModule,
         FormsModule,
+        SpinnerComponent
+    ],
+    providers: [
+        // { provide: HTTP_INTERCEPTORS, useClass: SpinnerInterceptor, multi: true },
     ],
     templateUrl: 'editstatus.component.html',
     styleUrls: ['editstatus.component.css']
@@ -42,6 +50,8 @@ export class EditStatusComponent implements OnInit {
     contentStatusColer: string = "var(--nist-green-default);"
     resourceType: string = "resource";
 
+    loading: boolean = false;
+
     @Input() mdrec: NerdmRes;
     @Input() forceDisplay: boolean = false;  // if true, display the message even if there is no update details. This is used to display a message when the record is in outside-midas mode and there is no update details.
 
@@ -57,6 +67,7 @@ export class EditStatusComponent implements OnInit {
         public globalsvc: GlobalService,
         private cdr: ChangeDetectorRef,
         private datePipe: DatePipe,
+        public spinner: SpinnerService,
         public lpService: LandingpageService) {
 
         effect(() => {
@@ -107,6 +118,10 @@ export class EditStatusComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.spinner.watchLoading((loading) => {
+            this.loading = loading;
+        });
+        
         if(this.mdrec)
             this.setContentStatusColor(this.mdrec);
     }

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.service.spec.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.service.spec.ts
@@ -43,10 +43,10 @@ describe('EditStatusService', () => {
     });
 
     it('setable', () => {
-        svc._setLastUpdated(updateDetails);
-        svc._setEditMode(EDIT_MODES.EDIT_MODE);
-        svc._setUserID("Hank");
-        svc._setAuthorized(false);
+        svc.setLastUpdated(updateDetails);
+        svc.setEditMode(EDIT_MODES.EDIT_MODE);
+        svc.setUserID("Hank");
+        svc.setAuthorized(false);
 
         expect(svc.lastUpdated._updateDate).toEqual("today");
         expect(svc.lastUpdated.userAttributes).toEqual(userAttributes);
@@ -57,7 +57,7 @@ describe('EditStatusService', () => {
 
     it('watchable remote start', () => {
         let resID = "";
-        svc._watchRemoteStart((ev) => {
+        svc.watchRemoteStart((ev) => {
             resID = ev.resID;
         });
         expect(resID).toEqual("");

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/editstatus.service.ts
@@ -18,10 +18,13 @@ export class EditStatusService {
     public EDIT_MODES: any = LandingConstants.editModes;
     public editMode = signal("");
 
-    isEditMode: Signal<boolean> = computed(() => {
-        return (this.editMode() == this.EDIT_MODES.EDIT_MODE)
-    });
+    // isEditMode: Signal<boolean> = computed(() => {
+    //     return (this.editMode() == this.EDIT_MODES.EDIT_MODE)
+    // });
 
+    isEditMode() {
+        return this._editMode.value == this.EDIT_MODES.EDIT_MODE;
+    }
     /**
      * construct the service
      */
@@ -34,7 +37,7 @@ export class EditStatusService {
      */
     get lastUpdated() : UpdateDetails { return this._lastupdate; }
     private _lastupdate : UpdateDetails = null;   // null object means unknown
-    _setLastUpdated(updateDetails : UpdateDetails) { this._lastupdate = updateDetails; }
+    public setLastUpdated(updateDetails : UpdateDetails) { this._lastupdate = updateDetails; }
 
     /**
      * flag indicating the current edit mode.  
@@ -43,7 +46,7 @@ export class EditStatusService {
      */
     _editMode : BehaviorSubject<string> =
         new BehaviorSubject<string>(LandingConstants.editModes.VIEWONLY_MODE);
-    _setEditMode(val : string) { 
+    public setEditMode(val : string) { 
         this._editMode.next(val); 
         this._isEditMode.next(val == this.EDIT_MODES.EDIT_MODE);
     }
@@ -63,7 +66,7 @@ export class EditStatusService {
      */
     _editType : BehaviorSubject<string> =
         new BehaviorSubject<string>(LandingConstants.editModes.VIEWONLY_MODE);
-    _setEditType(val : string) { 
+    public setEditType(val : string) { 
         this._editType.next(val); 
     }
     public watchEditType(subscriber) {
@@ -103,14 +106,14 @@ export class EditStatusService {
      */
     get hasError() : boolean { return this._error; }
     private _error : boolean = false;
-    _setError(val : boolean) { this._error = val; }
+    public setError(val : boolean) { this._error = val; }
 
     /**
      * Behavior subject to remotely start the edit function. This is used when user login
      * and the page was redirected to current page with parameter 'editmode' set to true.
      */
     private _remoteStart : BehaviorSubject<object> = new BehaviorSubject<object>({resID: "", nologin: false});
-    _watchRemoteStart(subscriber) {
+     public watchRemoteStart(subscriber) {
         this._remoteStart.subscribe(subscriber);
     }
 
@@ -119,7 +122,7 @@ export class EditStatusService {
      */
     get userID() : string { return this._userid; }
     private _userid : string = null;
-    _setUserID(id : string) { this._userid = id; }
+    public setUserID(id : string) { this._userid = id; }
     
     /**
      * a flag indicating whether the current user has been authenticated.
@@ -131,7 +134,7 @@ export class EditStatusService {
      */
     get authorized() : boolean { return this._authzd; }
     private _authzd : boolean = false;
-    _setAuthorized(val : boolean) { this._authzd = val; }
+    public setAuthorized(val : boolean) { this._authzd = val; }
 
 
     /**

--- a/oar-lps/libs/oarlps/src/lib/landing/editcontrol/metadataupdate.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/editcontrol/metadataupdate.service.ts
@@ -715,7 +715,7 @@ export class MetadataUpdateService {
                   
                 if (err instanceof daperrs.IDNotFound) {
                     this.resetMetadata();
-                    this.edstatsvc._setEditMode(this.EDIT_MODES.OUTSIDE_MIDAS_MODE);
+                    this.edstatsvc.setEditMode(this.EDIT_MODES.OUTSIDE_MIDAS_MODE);
                 }
                 else {
                     console.error("Failed to retrieve draft metadata changes: server error:" + err.message);

--- a/oar-lps/libs/oarlps/src/lib/landing/title/title-edit/title-edit.component.spec.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/title/title-edit/title-edit.component.spec.ts
@@ -61,14 +61,14 @@ describe('TitleEditComponent', () => {
     });
 
     it('editMode', () => {
-        edstatsvc.editMode.set(LandingConstants.editModes.EDIT_MODE);
+        edstatsvc.setEditMode(LandingConstants.editModes.EDIT_MODE);
         expect(edstatsvc.isEditMode()).toBeTruthy();
 
         fixture.detectChanges();
         let buttonElement = fixture.nativeElement.querySelector('button');
         expect(buttonElement).toBeTruthy();
 
-        edstatsvc.editMode.set(LandingConstants.editModes.DONE_MODE);
+        edstatsvc.setEditMode(LandingConstants.editModes.DONE_MODE);
         expect(edstatsvc.isEditMode()).toBeFalsy();
 
         fixture.detectChanges();

--- a/oar-lps/libs/oarlps/src/lib/landing/title/title-edit/title-edit.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/title/title-edit/title-edit.component.ts
@@ -58,6 +58,7 @@ export class TitleEditComponent {
                 private notificationService: NotificationService) 
     {
         effect(() => {
+            console.log("isEditMode", this.edstatsvc.isEditMode());
             if(this.edstatsvc.isEditMode()){
                 this.chref.detectChanges();
             }

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner-interceptor.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner-interceptor.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor } from '@angular/common/http';
+import { finalize } from 'rxjs/operators';
+import { SpinnerService } from './spinner.service';
+
+@Injectable()
+export class SpinnerInterceptor implements HttpInterceptor {
+    constructor(private spinner: SpinnerService) {}
+
+    intercept(req, next) {
+        this.spinner.show();
+
+        return next.handle(req).pipe(
+            finalize(() => this.spinner.hide())
+        );
+    }
+}

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.html
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.html
@@ -1,0 +1,7 @@
+<div class="overlay" *ngIf="loading && !local">
+    <div class="spinner"></div>
+</div>
+
+<div class="normal-spinner" *ngIf="loading && local">
+    <fa-icon [icon]="faSpinner" [animation]="'spin'" size="sm"></fa-icon>
+</div>

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.scss
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.scss
@@ -1,0 +1,37 @@
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.normal-spinner {
+    position: relative;
+    width: inherit;
+    height: inherit;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+/* Simple CSS spinner */
+.spinner {
+    border: 6px solid #ccc;
+    border-top: 6px solid #1976d2;
+    border-radius: 50%;
+    width: 100px;
+    height: 100px;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.spec.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync  } from '@angular/core/testing';
+import { SpinnerComponent } from './spinner.component';
+
+describe('DoneComponent', () => {
+  let component: SpinnerComponent;
+  let fixture: ComponentFixture<SpinnerComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ SpinnerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SpinnerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.component.ts
@@ -1,0 +1,27 @@
+import { Component, Input } from '@angular/core';
+import { SpinnerService } from './spinner.service';
+import { CommonModule } from '@angular/common';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+    selector: 'app-spinner',
+    templateUrl: './spinner.component.html',
+    styleUrls: ['./spinner.component.scss'],
+    standalone: true,
+    imports: [ CommonModule, FontAwesomeModule ]
+})
+export class SpinnerComponent {
+    loading: boolean = false;
+    faSpinner = faSpinner;
+    
+    @Input() local: boolean = false;
+
+    constructor(public spinner: SpinnerService) { }
+
+    ngOnInit() {
+        this.spinner.watchLoading((loading) => {
+            this.loading = loading;
+        });
+    }
+}

--- a/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/spinner/spinner.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class SpinnerService {
+    private requests = 0;
+    private maxTimeout: any;
+
+    private loading = new BehaviorSubject<boolean>(false);
+    loading$ = this.loading.asObservable();
+
+    _authorized : BehaviorSubject<boolean> =
+        new BehaviorSubject<boolean>(false);
+    public show() { 
+        this.requests++;
+        this.loading.next(true); 
+
+        // Fail-safe: auto-hide after 20s
+        clearTimeout(this.maxTimeout);
+        this.maxTimeout = setTimeout(() => {
+            console.warn('Spinner auto-hidden due to timeout');
+            this.hide(true);
+        }, 20000);        
+    }
+    public watchLoading(subscriber) {
+        this.loading.subscribe(subscriber);
+    }      
+    
+    public hide(force: boolean = false) {
+        this.requests = Math.max(0, this.requests - 1);
+
+        if (this.requests === 0 || force) {
+            this.loading.next(false);
+            this.requests = 0; // reset request count
+            clearTimeout(this.maxTimeout);
+        }
+    }
+}

--- a/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.html
+++ b/oar-lps/libs/oarlps/src/lib/sidebar/sidebar.component.html
@@ -39,23 +39,23 @@
             </div>
             
             <div class="help-title headerbar" (click)="this.showNextSteps = !this.showNextSteps">
-                <div *ngIf="!hasRequiredItems && !hasWarnItems && !hasRecommendedItems; else nextSteps">
-                    {{msgCompleted}}
-                </div>
-                <ng-template #nextSteps>
-                    Next Steps:
-                    <i class="fas expand-btn amplifiable" 
-                        [class.amplified]="isMouseOverNextSteps" 
-                        (mouseover)="isMouseOverNextSteps = true"
-                        (mouseleave)="isMouseOverNextSteps = false"
-                        [ngClass]="{'fa-caret-right': !showNextSteps, 'fa-caret-down': showNextSteps}" 
-                        aria-label="Show warning steps">
-                    </i>
-                </ng-template>
+                Next Steps:
+                <i class="fas expand-btn amplifiable" 
+                    [class.amplified]="isMouseOverNextSteps" 
+                    (mouseover)="isMouseOverNextSteps = true"
+                    (mouseleave)="isMouseOverNextSteps = false"
+                    [ngClass]="{'fa-caret-right': !showNextSteps, 'fa-caret-down': showNextSteps}" 
+                    aria-label="Show warning steps">
+                </i>
             </div>
             
             <!-- Suggestions -->
             <!-- @if(!isTestData){ -->
+            <div *ngIf="!hasRequiredItems && !hasWarnItems && !hasRecommendedItems; else nextSteps"
+                style="padding: 10px"
+                [innerHTML]="msgCompleted">
+            </div>
+            <ng-template #nextSteps>
                 <div class="section-content" [@nextStepsExpand]="showNextSteps ? 'visible' : 'hidden'">
                 
                     <div *ngIf="(!suggestions['req'] || suggestions['req'].length == 0) 
@@ -86,6 +86,7 @@
                         </suggestions>
                     </div>
                 </div>       
+            </ng-template>
             <!-- } -->
         </div>
     </div>

--- a/oar-lps/libs/oarlps/src/public-api.ts
+++ b/oar-lps/libs/oarlps/src/public-api.ts
@@ -125,3 +125,7 @@ export * from './lib/landing/revision-details/revision-details.component';
 
 export * from './lib/landing/people/people.component';
 export * from './lib/landing/landingpage.service';
+
+export * from './lib/shared/spinner/spinner.component';
+export * from './lib/shared/spinner/spinner.service';
+export * from './lib/shared/spinner/spinner-interceptor';

--- a/package.json
+++ b/package.json
@@ -46,8 +46,14 @@
         "typescript": "5.4.5"
     },
     "dependencies": {
+        "@fortawesome/angular-fontawesome": "^0.15.0",
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0",
+        "@fortawesome/free-brands-svg-icons": "^6.6.0",        
         "@ng-select/ng-select": "^12.0.6",
         "js-yaml": "^4.1.0",
-        "rxjs": "~7.8.1"
+        "rxjs": "~7.8.1",
+        "listr2": "^9.0.5"
     }
 }

--- a/pdr-lps/src/app/landing/landingpage.component.html
+++ b/pdr-lps/src/app/landing/landingpage.component.html
@@ -97,11 +97,11 @@
   
 <!-- Show spinner -->
 <div *ngIf="!_showContent">
-    <pdr-done [message]="loadingMessage"></pdr-done>
+    <pdr-msg-page [message]="loadingMessage"></pdr-msg-page>
 </div>
 
 <!-- Display done page -->
 <div [ngStyle]="{'display': displaySpecialMessage? 'block' : 'none'}">
-    <pdr-done [message]='message'></pdr-done>
+    <pdr-msg-page [message]='message'></pdr-msg-page>
 </div>
   


### PR DESCRIPTION
This branch made the following changes:

1. Added a global spinner service. Any http call will trigger a spinner to display. The spinner will disappear either http call gets response or timeout at 20 seconds. 
    For Wizard, the spinner is overlay to the whole page. Typically it will show up when page is loading or submits the request at the last step.
    For Daptool, the spinner will replace the text "Save" inside the green bubble at top right corner under the control buttons. The spinner will display whenever there is a http calls to dbio.
    No change to public side.

2. Fixed the display issue of the help content when all items are satisfied.
3. When URL has no parameter, display the landing page in read only mode.

Tested locally and in docker.