### PR TITLE
Fixed section title backcolor and footer links wrapping. Added core t…

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
@@ -129,12 +129,12 @@
                 </div>
             }
 
-            <div style="flex-grow: 8; text-align: left; padding-top: 5px;">
+            <div style="flex-grow: 8; text-align: left; padding-top: 13px;">
                 <span class="grey-color">Click on the file/row in the table below to view more
                     details.</span>
             </div>
 
-            <div class="grey-color" style="flex-grow: 2; text-align: right;padding-top: 0.8em;">
+            <div class="grey-color" style="flex-grow: 2; text-align: right;padding-top: 13px;">
                 Total No. files:
                 <span 
                     [ngStyle]="{color: fileCountColor}" 

--- a/oar-lps/libs/oarlps/src/lib/landing/section-title/section-title.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/section-title/section-title.component.ts
@@ -22,6 +22,7 @@ export class SectionTitleComponent {
     sectionWidth: number;
     backColor: string = '#003c97';
     maxWidth: number = 1000;
+    sectionHeaderSetup: boolean = false;
 
     @Input() sectionTitle: string = "Hello"; 
     @Input() inBrowser: boolean = false;
@@ -41,7 +42,9 @@ export class SectionTitleComponent {
 
         this.globalService.watchColorPalette((colorPalette) => {
             this.colorScheme = colorPalette;
-            this.updateSectionHeaderBackground();
+
+            if(!this.sectionHeaderSetup)
+                this.updateSectionHeaderBackground();
         })
     }
 
@@ -52,7 +55,10 @@ export class SectionTitleComponent {
         let width = this.globalService.getTextWidth(this.sectionTitle)
         this.sectionWidth = width;
 
-        this.updateSectionHeaderBackground();
+        if (this.colorScheme && this.colorScheme.defaultVar && !this.sectionHeaderSetup) {
+            this.updateSectionHeaderBackground();
+            this.sectionHeaderSetup = true;
+        }
     }
 
     updateSectionHeaderBackground(){

--- a/oar-lps/libs/oarlps/src/lib/landing/section-title/section-title.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/section-title/section-title.component.ts
@@ -41,6 +41,7 @@ export class SectionTitleComponent {
 
         this.globalService.watchColorPalette((colorPalette) => {
             this.colorScheme = colorPalette;
+            this.updateSectionHeaderBackground();
         })
     }
 
@@ -51,8 +52,11 @@ export class SectionTitleComponent {
         let width = this.globalService.getTextWidth(this.sectionTitle)
         this.sectionWidth = width;
 
-        if(this.inBrowser && this.colorScheme)
-            this.d3Service.drawSectionHeaderBackground(this.svg, this.sectionTitle, this.sectionWidth, this.colorScheme.defaultVar, width, "#"+this.sectionTag);    
+        this.updateSectionHeaderBackground();
     }
 
+    updateSectionHeaderBackground(){
+        if(this.inBrowser && this.colorScheme)
+            this.d3Service.drawSectionHeaderBackground(this.svg, this.sectionTitle, this.sectionWidth, this.colorScheme.defaultVar, this.sectionWidth, "#"+this.sectionTag);    
+    }
 }


### PR DESCRIPTION
Issue: The background color of the section header is black. Should be green. 
Cause: the color variable was set after page init. 
Fix: The fix is to create the section header only after the color variable is set. 
 
Tested in local docker.
