### PR TITLE
Use Fontawesome icons for Primeng tree rable toggler.

### DIFF
--- a/midas-author/lps/src/styles.scss
+++ b/midas-author/lps/src/styles.scss
@@ -3,17 +3,17 @@
 :root {
     /* Colors */
     --science-theme-background-default: #008097;
-    --science-theme-background-hover: #02a3bf;
+    --science-theme-background-hover: #d9f9ff;
     --science-theme-background-dark: #007287;
     --science-theme-background-light: #f5fbfd;
     --science-theme-background-light2: #e3f7fd;
     --science-theme-background-blue: #017abb;
-    --science-theme-background-blue-hover: #0097e8;
+    --science-theme-background-blue-hover: #cdeeff;
     --nist-green-default: #257a2d;
     --nist-green-dark: #1c6022;
     --nist-green-light: #6bad73;
     --nist-green-lighter: #f0f7f1;
-    --nist-green-hover: #37ab42;
+    --nist-green-hover: #def8e0;
     --nist-blue-default: #12659c;
     --nist-blue-dark: #0c4870;
     --nist-blue-light: #197dc0;
@@ -35,7 +35,38 @@
     --chips-background-light: #e3efff;
     --chips-background-lighter: #f7f7fa;
     --chips-background-dark: #00076c;
-    --chips-background-hover: #237bff;
+    --chips-background-hover: #e4efff;
+
+    // Brown
+        --background-orange-default: #e53b10;
+        --background-orange-light: #ffd49d;
+        --background-orange-lighter: #fff2e1;
+        --background-orange-dark: rgb(43, 28, 0);
+        --background-orange-hover: #fce9d2;
+        // Beach Sunset
+        --background-beach-sunset-default: #1b4965;
+        --background-beach-sunset-light: #5fa8d3;
+        --background-beach-sunset-lighter: #cae9ff;
+        --background-beach-sunset-dark: #0d3046;
+        --background-beach-sunset-hover: #c1e8ff;
+        // Rosy Flamingo
+        --background-orange1-default: #67595e;
+        --background-orange1-light: #f1e8e8;
+        --background-orange1-lighter: #faf6f5;
+        --background-orange1-dark: rgb(43, 16, 0);
+        --background-orange1-hover: #f1e8e8;
+        // Purple
+        --background-purple-default: #bf619e;
+        --background-purple-light: #ffe6f6;
+        --background-purple-lighter: #fdf3f9;
+        --background-purple-dark: #71385d;
+        --background-purple-hover: #ffe6f6;
+        // AM Green
+        --background-am-green-default: #2f983a;
+        --background-am-green-dark: #1c6022;
+        --background-am-green-light: color-mix(in srgb, var(--background-am-green-default) 25%, transparent);
+        --background-am-green-lighter: color-mix(in srgb, var(--background-am-green-default) 5%, transparent);
+        --background-am-green-hover: #cfffd4;
 }
 
 .oar-button {

--- a/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.html
+++ b/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.html
@@ -172,6 +172,11 @@
                     </td>
                 </tr>
             </ng-template>
+
+            <!-- 👇 Custom toogler icons -->
+            <ng-template pTemplate="togglericon" let-open>
+                <fa-icon [icon]="open ? faChevronDown : faChevronRight"></fa-icon>
+            </ng-template>
         </p-treeTable>
     </div>
 </div>

--- a/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.ts
@@ -34,7 +34,9 @@ import {
     faEyeSlash,
     faCloudDownload,
     faDownload,
-    faCheck
+    faCheck,
+    faChevronRight,
+    faChevronDown
 } from '@fortawesome/free-solid-svg-icons';
 import { iconClass } from '../../shared/globals/globals';
 
@@ -282,6 +284,8 @@ export class TreetableComponent implements OnInit, AfterViewInit {
     faCloudDownload = faCloudDownload;
     faDownload = faDownload;
     faCheck = faCheck;
+    faChevronRight = faChevronRight;
+    faChevronDown = faChevronDown;
 
     isMouseOver: boolean = false;
 

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.css
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.css
@@ -80,4 +80,3 @@ fa-icon.small svg {
 .badge {
     left: 0px;
 }
-

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
@@ -173,10 +173,23 @@
 
         <!-- Display tree table -->
         <!-- Available match modes are "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "lt", "lte", "gt" and "gte" -->
-        <p-treeTable #tt class="data-table" *ngIf="visible" [value]="files" [columns]="cols" selectionMode="single"
-            (onNodeExpand)="treeTableToggled($event)" (onNodeCollapse)="treeTableToggled($event)" [resizableColumns]="true"
-            dataKey="key" sortField="name" styleClass="p-treetable-sm" [scrollable]="virtualScroll"
-            [scrollHeight]="treeTableHeight + 'px'" [virtualScroll]="virtualScroll" [virtualScrollItemSize]="57"
+        <p-treeTable 
+            #tt 
+            class="data-table" 
+            *ngIf="visible" 
+            [value]="files" 
+            [columns]="cols" 
+            selectionMode="single"
+            (onNodeExpand)="treeTableToggled($event)" 
+            (onNodeCollapse)="treeTableToggled($event)" 
+            [resizableColumns]="true"
+            dataKey="key" 
+            sortField="name" 
+            styleClass="p-treetable-sm" 
+            [scrollable]="virtualScroll"
+            [scrollHeight]="treeTableHeight + 'px'" 
+            [virtualScroll]="virtualScroll" 
+            [virtualScrollItemSize]="57"
             [globalFilterFields]="['name']">
             <ng-template pTemplate="caption">
                 <div style="text-align: right; height: 20px;margin-bottom: 10px;padding-top: 0px;border-color: 1px solid red;">
@@ -238,6 +251,7 @@
                     <td [ngStyle]="titleStyle(rowData)" (click)="openDetails(rowData)">
                         <p-treeTableToggler [rowNode]="rowNode" data-toggle="tooltip" title="Expand/Collapse">
                         </p-treeTableToggler>
+
                         <span data-toggle="tooltip" title="Click for more details">
                             <b>{{rowData.name}}</b> </span>
                         <span style="margin-left: .5em;" *ngIf="isLeaf(rowData)">
@@ -430,6 +444,11 @@
                         </div>
                     </td>
                 </tr>
+            </ng-template>
+
+            <!-- 👇 Custom toogler icons -->
+            <ng-template pTemplate="togglericon" let-open>
+                <fa-icon [icon]="open ? faChevronDown : faChevronRight"></fa-icon>
             </ng-template>
         </p-treeTable>
     

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.ts
@@ -41,7 +41,9 @@ import {
     faCaretRight,
     faLock,
     faCopy,
-    faHandPointRight
+    faHandPointRight,
+    faChevronRight,
+    faChevronDown
 } from '@fortawesome/free-solid-svg-icons';
 import { faCircle } from '@fortawesome/free-regular-svg-icons';
 
@@ -238,6 +240,8 @@ export class DatafilesPubComponent {
     faCopy = faCopy;
     faHandPointRight = faHandPointRight;
     faCircle = faCircle;
+    faChevronRight = faChevronRight;
+    faChevronDown = faChevronDown;
     
     @ViewChild('tt', { read: ElementRef }) public treeTable: ElementRef<any>;
     
@@ -266,7 +270,9 @@ export class DatafilesPubComponent {
             faCaretRight,
             faLock,
             faCopy,
-            faHandPointRight
+            faHandPointRight,
+            faChevronRight,
+            faChevronDown
         );  
 
         this.cols = [

--- a/oar-lps/libs/oarlps/src/lib/landing/tools/menu.component.css
+++ b/oar-lps/libs/oarlps/src/lib/landing/tools/menu.component.css
@@ -38,3 +38,7 @@ a:visited,
 a:focus {
     color: black !important ;
 }
+
+fa-icon {
+    margin-right: 3px;
+}

--- a/oar-lps/libs/oarlps/src/lib/landing/tools/menu.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/tools/menu.component.html
@@ -4,7 +4,7 @@
         <td [ngClass]="menuitem.isHeader? 'menu-header menu-body' : 'menu-item menu-body'" scope="row"
             [ngStyle]="menuStyle(menuitem.isHeader)"
             (click)="goToSection(menuitem.sectionName, menuitem.url)">
-            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" size="xs"></fa-icon>
+            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" ></fa-icon>
             {{menuitem.title}}
         </td>
     </tr>
@@ -13,18 +13,10 @@
 <!-- Use menu-->
 <table style="width: 100%;">
     <tr *ngFor="let menuitem of useMenu">
-        <!-- <td [ngClass]="menuitem.isHeader? 'menu-header menu-body' : 'menu-item menu-body'" scope="row"
-            [style.--background-default]="menuitem.isHeader? defaultColor: lighterColor"
-            [style.--background-lighter]="lighterColor" 
-            [style.--background-hover]="hoverColor"
-            (click)="goToSection(menuitem.sectionName, menuitem.url)">
-            <i [class]="menuitem.icon"></i>
-            {{menuitem.title}}
-        </td> -->
         <td [ngClass]="menuitem.isHeader? 'menu-header menu-body' : 'menu-item menu-body'" scope="row"
             [ngStyle]="menuStyle(menuitem.isHeader)"
             (click)="goToSection(menuitem.sectionName, menuitem.url)">
-            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" size="xs"></fa-icon>
+            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" ></fa-icon>
             {{menuitem.title}}
         </td>
     </tr>
@@ -32,7 +24,7 @@
         <td class="menu-item menu-body" scope="row" 
             [ngStyle]="menuStyle(false)">
             <a href="{{bulkDownloadURL}}" target="_blank">
-                <fa-icon [icon]="['fas', downloadIcon]" size="xs"></fa-icon>
+                <fa-icon [icon]="['fas', downloadIcon]" ></fa-icon>
                 Bulk Download
             </a>
         </td>
@@ -45,7 +37,7 @@
         <td [ngClass]="menuitem.isHeader? 'menu-header menu-body' : 'menu-item menu-body'" scope="row"
             [ngStyle]="menuStyle(menuitem.isHeader)"
             (click)="goToSection(menuitem.sectionName, menuitem.url)">
-            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" size="xs"></fa-icon>
+            <fa-icon *ngIf="menuitem.icon" [icon]="['fas', menuitem.icon]" ></fa-icon>
             {{menuitem.title}}
         </td>
     </tr>

--- a/oar-lps/libs/oarlps/src/lib/landing/topic/topic-edit/topic-edit.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/topic/topic-edit/topic-edit.component.html
@@ -73,6 +73,11 @@
                                     </td>
                                 </tr>
                             </ng-template>
+
+                            <!-- 👇 Custom toogler icons -->
+                            <ng-template pTemplate="togglericon" let-open>
+                                <fa-icon [icon]="open ? faChevronDown : faChevronRight"></fa-icon>
+                            </ng-template>
                         </p-treeTable>
                     </div>
                 </div>

--- a/oar-lps/libs/oarlps/src/lib/landing/topic/topic-edit/topic-edit.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/topic/topic-edit/topic-edit.component.ts
@@ -21,7 +21,9 @@ import {
     faSave,
     faUndo,
     faTrashCan,
-    faRecycle
+    faRecycle,
+    faChevronDown,
+    faChevronRight
 } from '@fortawesome/free-solid-svg-icons';
 
 export const ROW_COLOR = '#1E6BA1';
@@ -68,6 +70,8 @@ export class TopicEditComponent implements OnInit {
     faUndo = faUndo;
     faTrashCan = faTrashCan;
     faRecycle = faRecycle;
+    faChevronDown = faChevronDown;
+    faChevronRight = faChevronRight;
 
     @Input() record: NerdmRes = null;
     @Input() inBrowser: boolean;

--- a/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.html
+++ b/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.html
@@ -241,6 +241,11 @@
                 </td>
             </tr>
         </ng-template>
+
+        <!-- 👇 Custom toogler icons -->
+        <ng-template pTemplate="togglericon" let-open>
+            <fa-icon [icon]="open ? faChevronDown : faChevronRight"></fa-icon>
+        </ng-template>
     </p-treeTable>
 </div>
 <ng-template #filesLoading>

--- a/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.ts
@@ -28,7 +28,9 @@ import {
     faCircleArrowUp,
     faChartBar,
     faDownload,
-    faFileArrowDown
+    faFileArrowDown,
+    faChevronRight,
+    faChevronDown
 } from '@fortawesome/free-solid-svg-icons';
 import { iconClass } from '../shared/globals/globals';
 
@@ -119,6 +121,8 @@ export class MetricsComponent implements OnInit {
     faChartBar = faChartBar;
     faDownload = faDownload;
     faFileArrowDown = faFileArrowDown
+    faChevronRight = faChevronRight;
+    faChevronDown = faChevronDown;
 
     isMouseOver: boolean = false;
 

--- a/pdr-lps/src/assets/collection/color-palettes.json
+++ b/pdr-lps/src/assets/collection/color-palettes.json
@@ -25,7 +25,7 @@
             "lightVar": "var(--chips-background-light)",
             "lighterVar": "var(--chips-background-lighter)",
             "darkVar": "var(--chips-background-dark)",
-            "hoverVar": "#84b4db"        
+            "hoverVar": "var(--chips-background-hover)"       
     },
     "RosyFlamingo": {
             "defaultVar": "var(--background-orange-default)",

--- a/pdr-lps/src/styles.scss
+++ b/pdr-lps/src/styles.scss
@@ -5,17 +5,17 @@
 :root {
     /* Colors */
     --science-theme-background-default: #008097;
-    --science-theme-background-hover: #02a3bf;
+    --science-theme-background-hover: #d9f9ff;
     --science-theme-background-dark: #007287;
     --science-theme-background-light: #f5fbfd;
     --science-theme-background-light2: #e3f7fd;
     --science-theme-background-blue: #017abb;
-    --science-theme-background-blue-hover: #0097e8;
+    --science-theme-background-blue-hover: #cdeeff;
     --nist-green-default: #257a2d;
     --nist-green-dark: #1c6022;
     --nist-green-light: #6bad73;
     --nist-green-lighter: #f0f7f1;
-    --nist-green-hover: #37ab42;
+    --nist-green-hover: #def8e0;
     --nist-blue-default: #12659c;
     --nist-blue-dark: #0c4870;
     --nist-blue-light: #197dc0;
@@ -37,7 +37,7 @@
     --chips-background-light: #e3efff;
     --chips-background-lighter: #f7f7fa;
     --chips-background-dark: #00076c;
-    --chips-background-hover: #237bff;
+    --chips-background-hover: #e4efff;
     // Brown
     --background-orange-default: #e53b10;
     --background-orange-light: #ffd49d;
@@ -49,7 +49,7 @@
     --background-beach-sunset-light: #5fa8d3;
     --background-beach-sunset-lighter: #cae9ff;
     --background-beach-sunset-dark: #0d3046;
-    --background-beach-sunset-hover: #5fa8d3;
+    --background-beach-sunset-hover: #c1e8ff;
     // Rosy Flamingo
     --background-orange1-default: #67595e;
     --background-orange1-light: #f1e8e8;
@@ -61,13 +61,13 @@
     --background-purple-light: #ffe6f6;
     --background-purple-lighter: #fdf3f9;
     --background-purple-dark: #71385d;
-    --background-purple-hover: #fbb8e3;
+    --background-purple-hover: #ffe6f6;
     // AM Green
     --background-am-green-default: #2f983a;
     --background-am-green-dark: #1c6022;
     --background-am-green-light: color-mix(in srgb, var(--background-am-green-default) 25%, transparent);
     --background-am-green-lighter: color-mix(in srgb, var(--background-am-green-default) 5%, transparent);
-    --background-am-green-hover: #37ab42;
+    --background-am-green-hover: #cfffd4;
 }
 
 .oar-button {


### PR DESCRIPTION
Two fixes:

1. Use fontawesome icons in Primeng tree table toggler.
2. User normal size icons in the right-side menu bar.

Tested locally. 