### PR TITLE
Fix/taxonomy display

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/landing/topic/topic-pub/topic-pub.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/topic/topic-pub/topic-pub.component.ts
@@ -61,9 +61,8 @@ export class TopicPubComponent implements AfterContentInit {
             if(this.record['isPartOf'] && Array.isArray(this.record['isPartOf']) && 
             this.record['isPartOf'].length > 0) {
                 for (let c of this.record['isPartOf']) {
-                    let colDisplay = CollectionDisplay[collection.toUpperCase()] ? CollectionDisplay[collection.toUpperCase()] : "";    
-                    if (colDisplay != "") {
-                        return (c.title.toLowerCase().indexOf(colDisplay.toLowerCase()) > -1)
+                    if (c['@id'] && c['@id'].split('/').pop() == this.allCollections[collection].id) {
+                        return true;
                     } else {
                         return false;
                     }

--- a/oar-lps/libs/oarlps/src/lib/shared/collection-service/collection.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/collection-service/collection.service.ts
@@ -120,6 +120,12 @@ export class CollectionService {
         }
     }
 
+    /**
+     * Load color palettes from json file.
+     * @param pdrHome Url prefix for pdr home, default to './' which means the same domain and path as the current page. 
+     * In production, odrHome should be https://data.nist.gov/pdr/.
+     * @returns color-palettes.json data as an Observable
+     */
     public loadColorPalettesFromJson(pdrHome: string = './'): Observable<any> {
         return this.http.get(`${pdrHome}assets/collection/color-palettes.json`);
     }

--- a/oar-lps/libs/oarlps/src/lib/shared/collection-service/collection.service.ts
+++ b/oar-lps/libs/oarlps/src/lib/shared/collection-service/collection.service.ts
@@ -120,8 +120,8 @@ export class CollectionService {
         }
     }
 
-    public loadColorPalettesFromJson(): Observable<any> {
-        return this.http.get('./assets/collection/color-palettes.json');
+    public loadColorPalettesFromJson(pdrHome: string = './'): Observable<any> {
+        return this.http.get(`${pdrHome}assets/collection/color-palettes.json`);
     }
 
 }

--- a/pdr-lps/src/app/landing/landingpage.component.ts
+++ b/pdr-lps/src/app/landing/landingpage.component.ts
@@ -195,6 +195,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
     showStickMenu: boolean = false;
     landingPageURL: string;
     landingPageServiceStr: string;
+    pdrHomeURL: string | null | undefined = null;
 
     //Icons
     faList = faList;
@@ -247,6 +248,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         this.inBrowser = isPlatformBrowser(platformId);
         this.editMode = this.EDIT_MODES.VIEWONLY_MODE;
         this.delayTimeForMetricsRefresh = +this.cfg.get("delayTimeForMetricsRefresh", "300");
+        this.pdrHomeURL = this.cfg.get("links.pdrHome", "/");
 
         this.lpService.watchCurrentSection((currentSection) => {
             this.goToSection(currentSection);
@@ -283,7 +285,7 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         let cp: any;
         let colorPalettes: any;
 
-        this.collectionService.loadColorPalettesFromJson().subscribe({
+        this.collectionService.loadColorPalettesFromJson(this.pdrHomeURL).subscribe({
             next: (data) => {
                 colorPalettes = data;
 

--- a/pdr-lps/src/app/landing/landingpage.component.ts
+++ b/pdr-lps/src/app/landing/landingpage.component.ts
@@ -344,7 +344,6 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         this.allCollections = JSON.parse(JSON.stringify(this.collectionService.loadAllCollections()));
         this.getCollection();
         this.loadBannerUrl();
-        this.loadColorPalette();   
         
         if(this.inBrowser){
             this.cartChangeHandler = this.cartChanged.bind(this);
@@ -352,8 +351,10 @@ export class LandingPageComponent implements OnInit, AfterViewInit {
         }
         this.metricsData = new MetricsData();
 
-        // Clean up cart status storage
         if(this.inBrowser){
+            this.loadColorPalette();   
+
+            // Clean up cart status storage
             this.dataCartStatus = DataCartStatus.openCartStatus();
             this.dataCartStatus.cleanUpStatusStorage();
         }


### PR DESCRIPTION
Two fixes in this branch:
1. Use id instead of title to determine which taxonomy to display.
2. Only load color palette in browser side. And use pdrHome as prefix of color palette json url.

Tested in local docker. Confirmed that the server side error was gone.
 