### PR TITLE
Fixed search box layout in collection page.

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.css
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.css
@@ -80,3 +80,31 @@ fa-icon.small svg {
 .badge {
     left: 0px;
 }
+
+.search-wrapper {
+    /* display: inline-block; */
+    flex-grow: 8;
+    position: relative;
+    max-height: 37px;
+    overflow: hidden;
+    height: 30px;
+}
+
+.search-wrapper fa-icon {
+    position: absolute;
+    left: 10px;
+    top: 15px;
+    transform: translateY(-50%);
+    color: #888;
+    margin: 4px 4px 0 0
+}
+
+.search-wrapper input {
+    width: 100%;
+    padding: 0px 8px 0px 35px;
+    /* left padding makes space for icon */
+    box-sizing: border-box;
+    height: 25px;
+    background-color: #f0f0f0;
+    margin: 5px 0 0 0;
+}

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
@@ -3,7 +3,7 @@
 <div id="filelisting" *ngIf="displayDataSection" [ngClass]="displayMode == 'restrict' ? 'restrict-public' : ''">
     <div *ngIf="displayMode == 'restrict'">Note:  This dataset is designated as restricted public data; this file list will not be shown in the public version of this page.</div>
 
-    <div *ngIf="!inBrowser">
+    <div *ngIf="!inBrowser" style="height: 35px;">
         <div>
             <b>Files </b>
         </div>
@@ -21,21 +21,21 @@
         <div class="flex-container" style="margin-top: 2em;">
             <!-- 'Download all' and 'Add all to cart' buttons disabled if this is internal landing page -->
             @if(!isPublicSite) {
-                <div style="flex: 0 0 110px; text-align: left; margin-bottom: -.5em;padding-bottom: 0em;">
+                <div style="flex: 0 0 110px; text-align: left; margin-bottom: opx;margin-top: 5px;height: 35px;">
                     <span><b id="filelist-heading">Files</b></span>
                     <!-- <span class="fa-stack fa-lg icon-download grey-color" style="margin-right:-1em;" aria-label="Download all"
                         ngbTooltip="Download all disabled in edit mode">
                     </span> -->
 
                     <!-- Download icon in MIDAS side -->
-                    <span class="fa-stack grey-color" size="2x" style="margin: -5px -22px 0 10px" aria-label="Download all"
+                    <span class="fa-stack grey-color" size="2x" style="margin: 0px -22px 0 10px" aria-label="Download all"
                         ngbTooltip="Download all disabled in edit mode">
                         <fa-icon [icon]="faCircle" class="fa-stack-2x" style="scale: 1.5;right: 20px;top: 8px;"></fa-icon>
                         <fa-icon [icon]="faDownload" class="fa-stack-1x small" style="top: 5px;"></fa-icon>
                     </span>
 
                     <!-- Add all to cart icon in MIDAS side -->
-                    <span class="fa-stack grey-color" size="2x" style="margin: -5px -2em 0px 10px" aria-label="Add all to data cart"
+                    <span class="fa-stack grey-color" size="2x" style="margin: 0px -2em 0px 10px" aria-label="Add all to data cart"
                         ngbTooltip="Add all to data cart disabled in edit mode">
                         <fa-icon [icon]="faCircle" class="fa-stack-2x" style="scale: 1.5;right: 20px;top: 8px;"></fa-icon>
                         <fa-icon [icon]="faCartPlus" class="fa-stack-1x small" style="top: 7px;left: -2px;"></fa-icon>
@@ -47,7 +47,7 @@
                 </div>
             }
             @else {
-                <div style="flex: 0 0 120px; text-align: left; padding-bottom: 0em;">
+                <div style="flex: 0 0 120px; text-align: left; padding-bottom: 0em;height: 35px;">
                     <span><b id="filelist-heading">Files </b> </span>
                     <!-- <a class="fa-stack fa-lg icon-download" style="width: 30px;" (click)="downloadAllFiles()" aria-label="Download all" -->
 
@@ -134,6 +134,24 @@
                     details.</span>
             </div>
 
+            <div class="search-wrapper">
+                <fa-icon 
+                    [icon]="faMagnifyingGlass" 
+                    size="sm" 
+                    data-toggle="tooltip" 
+                    title="Search on file or folder name"
+                    aria-label="Search on file or folder name">
+                </fa-icon>
+
+                <input 
+                    type="text" 
+                    pInputText 
+                    size="50" 
+                    placeholder="Search on file or folder name ..." 
+                    [(ngModel)]="searchText"
+                    (input)="toogleTree(true);filterTreeTable($event.target.value)">
+            </div>
+
             <div class="grey-color" style="flex-grow: 2; text-align: right;padding-top: 13px;">
                 Total No. files:
                 <span 
@@ -192,8 +210,7 @@
             [virtualScrollItemSize]="57"
             [globalFilterFields]="['name']">
             <ng-template pTemplate="caption">
-                <div style="text-align: right; height: 20px;margin-bottom: 10px;padding-top: 0px;border-color: 1px solid red;">
-                    <!-- <i class="pi pi-search" style="margin:4px 4px 0 0" aria-label="Search on file or folder name"></i> -->
+                <!-- <div class="search-wrapper">
                     <fa-icon 
                         [icon]="faMagnifyingGlass" 
                         size="sm" 
@@ -205,11 +222,7 @@
                     <input type="text" pInputText size="50" placeholder="Search on file or folder name ..."
                         [(ngModel)]="searchText" (input)="toogleTree(true);tt.filterGlobal($event.target.value, 'contains')"
                         style="height: 20px;margin: 0 0px 20px 0;width: 60%;background-color: #f0f0f0;">
-                    <!-- <button pButton type="submit" class="p-button-sm btn-labeled" id="btn-reset"
-                        (click)="searchText='';tt.filterGlobal('', 'contains')" label="Reset"
-                        [ngStyle]="{'margin-top':'0px','width':'max-content','height': '26px', 'background-color':'var(--nist-blue-default)', 'color': 'white'}">
-                    </button> -->
-                </div>
+                </div> -->
             </ng-template>
             <ng-template pTemplate="header" let-columns>
                 <tr>

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.ts
@@ -16,6 +16,7 @@ import { UserMessageService } from '../../../frame/usermessage.service';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { TreeTableModule } from 'primeng/treetable';
+import { TreeTable } from 'primeng/treetable';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { BadgeModule } from 'primeng/badge';
@@ -243,7 +244,8 @@ export class DatafilesPubComponent {
     faChevronRight = faChevronRight;
     faChevronDown = faChevronDown;
     
-    @ViewChild('tt', { read: ElementRef }) public treeTable: ElementRef<any>;
+    // @ViewChild('tt', { read: ElementRef }) public treeTable: ElementRef<any>;
+    @ViewChild('tt') treeTable!: TreeTable; 
     
     constructor(private cartService: CartService,
                 public breakpointObserver: BreakpointObserver,
@@ -1185,4 +1187,7 @@ export class DatafilesPubComponent {
         this.gaService.gaTrackEvent('homepage', event, title, url);
     }      
 
+    filterTreeTable(filterText: string) {
+        this.treeTable.filterGlobal(filterText, 'contains')
+    }
 }

--- a/oar-lps/libs/oarlps/src/lib/landing/resultlist/resultlist.component.css
+++ b/oar-lps/libs/oarlps/src/lib/landing/resultlist/resultlist.component.css
@@ -82,11 +82,27 @@
 }
 
 .search-wrapper {
-    display: inline-block;
+    /* display: inline-block; */
+    position: relative;
     max-height: 37px;
     overflow: hidden;
     margin: 0px;
     margin-bottom: 0px;
+}
+
+.search-wrapper fa-icon {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #888;
+}
+
+.search-wrapper input {
+    width: 100%;
+    padding: 2px 8px 8px 35px;
+    /* left padding makes space for icon */
+    box-sizing: border-box;
 }
 
 SELECT {

--- a/oar-lps/libs/oarlps/src/lib/landing/resultlist/resultlist.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/resultlist/resultlist.component.html
@@ -33,17 +33,14 @@
             <!-- Search text -->
             <div class="td" style="width: auto;padding-right: 5px;">
                 <span class="p-input-icon-right search-wrapper" style="width: 100%;">
-                    <!-- <i class="pi pi-search" style="top: 25px;"></i> -->
-
                     <fa-icon 
                         [icon]="faMagnifyingGlass" 
-                        style="top: 25px;">
+                        style="top: 23px;">
                     </fa-icon>
 
                     <label for="freeTextSearch" class="sr-only">Free Text Search</label>
                     <input id="freeTextSearch" type="text" pInputText [(ngModel)]="searchPhases"
-                        placeholder="Search for" (input)="filterResults()"
-                        [style]="{'text-align': 'left', 'height':'30px','width': '100%','padding-bottom':'0px','padding-top':'0px','margin-bottom':'0px','border-radius':'3px'}">
+                        placeholder="Search for" (input)="filterResults()">
                 </span>
             </div>
         </div>


### PR DESCRIPTION
**Issue**: In collection landing pages, the search icon in the free text search box in the search result header pushed the search box down, causing the box to shortened in height (see, for example, the [Forensics collection](https://data.nist.gov/od/id/pdr0-0001)).

**Root cause**: the recent icon change brook the styles.

Tested locally. Local docker was working but no collection for testing.