### PR TITLE
Fixed host name.

### DIFF
--- a/pdr-lps/src/app/app.component.ts
+++ b/pdr-lps/src/app/app.component.ts
@@ -67,9 +67,9 @@ export class AppComponent {
         if(this.inBrowser){
             this.gaCode = this.cfg.get("gaCode", "") as string;
             this.ga4Code = this.cfg.get("ga4Code", "") as string;
-            let homeurl = this.cfg.get("links.portalBase", "data.nist.gov") as string;
+            let homeurl = this.cfg.get("links.portalBase", "https://data.nist.gov/") as string;
 
-            const url = new URL("https://" + homeurl);
+            const url = new URL(homeurl);
             this.hostName = url.hostname;
 
 


### PR DESCRIPTION
Issue: wrong host name in ngAfterViewInit() for Google analytics.
Ticket: https://sgitlab.nist.gov/oar-odd/landing-page-service/-/work_items/25
Root cause: the default home url did not include "https://".
Fix: changed default home url from "data.nist.gov/" to "https://data.nist.gov/" .

Tested locally and in local docker.
