### PR TITLE
Move primeng and bootstrap style sheet from angular.json to style.scs…

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.html
+++ b/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.html
@@ -139,11 +139,9 @@
                     <td [ngStyle]="bodyStyle(statusWidth)">
                         <div id="downloadstatus" *ngIf="rowData.cartItem" style="display:inline;"
                             [ngStyle]="{'color':getDownloadStatusColor(rowData.cartItem.downloadStatus)}">
-                            <!-- <i [class]="getIconClass(rowData.cartItem.downloadStatus)" style="margin-right: .5em;"
-                                aria-hidden="true" data-toggle="tooltip" title="{{rowData.cartItem.downloadStatus}}"></i> -->
 
                             <fa-icon 
-                                *ngIf="getIconClass(rowData.cartItem.downloadStatus)"
+                                *ngIf="getIconClass(rowData.cartItem.downloadStatus) && rowData.cartItem.downloadStatus != 'downloading'"
                                 [icon]="['fas', getIconClass(rowData.cartItem.downloadStatus)]" 
                                 style="margin-right: .5em;"
                                 aria-hidden="true"
@@ -152,8 +150,13 @@
                                 title="{{rowData.cartItem.downloadStatus}}">
                             </fa-icon>
 
-                            <p-progressSpinner *ngIf="rowData.cartItem.downloadStatus == 'downloading'"
-                                [style]="{width: '12px', height: '12px', 'margin-right': '.5em'}"></p-progressSpinner>
+                            <fa-icon 
+                                *ngIf="rowData.cartItem.downloadStatus == 'downloading'" 
+                                style="margin-right: 5px;"
+                                [icon]="faSpinner" 
+                                [animation]="'spin'">
+                            </fa-icon>
+
                             <span
                                 *ngIf="rowData.cartItem.downloadStatus == 'error' || rowData.cartItem.downloadStatus == 'failed'; else normal"
                                 style="cursor: pointer;"

--- a/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/datacart/treetable/treetable.component.ts
@@ -36,7 +36,8 @@ import {
     faDownload,
     faCheck,
     faChevronRight,
-    faChevronDown
+    faChevronDown,
+    faSpinner
 } from '@fortawesome/free-solid-svg-icons';
 import { iconClass } from '../../shared/globals/globals';
 
@@ -286,6 +287,7 @@ export class TreetableComponent implements OnInit, AfterViewInit {
     faCheck = faCheck;
     faChevronRight = faChevronRight;
     faChevronDown = faChevronDown;
+    faSpinner = faSpinner;
 
     isMouseOver: boolean = false;
 

--- a/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
+++ b/oar-lps/libs/oarlps/src/lib/landing/data-files/datafiles-pub/datafiles-pub.component.html
@@ -60,8 +60,7 @@
                         <ng-template #show_spinner1><i class="fas fa-spinner fa-spin fa-stack-1x spinner fa-xs"
                                 aria-hidden="true"></i></ng-template> -->
 
-                        <span class="fa-stack" size="2x" style="margin: -5px -22px 0 10px" aria-label="Download all"
-                            ngbTooltip="Download all">
+                        <span class="fa-stack" size="2x" style="margin: -5px -22px 0 10px" aria-label="Download all">
                             <fa-icon 
                                 [icon]="faCircle" 
                                 class="fa-stack-2x" 
@@ -100,8 +99,7 @@
                         <ng-template #show_spinner><i class="fas fa-spinner fa-spin fa-stack-1x spinner"
                                 aria-hidden="true"></i></ng-template> -->
 
-                        <span class="fa-stack" size="2x" style="margin: 8px -2em 0px 10px" aria-label="Add all to cart"
-                            ngbTooltip="Add all to cart">
+                        <span class="fa-stack" size="2x" style="margin: 8px -2em 0px 10px" aria-label="Add all to cart">
                             <fa-icon 
                                 [icon]="faCircle" 
                                 class="fa-stack-2x" 

--- a/pdr-lps/angular.json
+++ b/pdr-lps/angular.json
@@ -32,14 +32,8 @@
             ],
             "styles": [
               "src/styles.scss",
-              "../node_modules/primeng/resources/primeng.css",
-              "../node_modules/primeicons/primeicons.css",
-              "../node_modules/primeflex/primeflex.css",
-              "../node_modules/primeng/resources/themes/saga-blue/theme.css",
-              "../node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles/main.css",
               "src/app/content/modal.less",
-              "../node_modules/ngx-toastr/toastr.css",
               "../node_modules/@ng-select/ng-select/themes/default.theme.css"
             ],
             "vendorChunk": true,

--- a/pdr-lps/src/styles.scss
+++ b/pdr-lps/src/styles.scss
@@ -1,3 +1,11 @@
+@import "primeng/resources/themes/saga-blue/theme.css";
+@import "primeng/resources/primeng.min.css";
+@import "primeicons/primeicons.css";
+@import "primeflex/primeflex.css";
+
+@import "../../node_modules/ngx-toastr/toastr";
+@import "bootstrap/scss/bootstrap";
+
 * {
     font-family: sans-serif;
 }


### PR DESCRIPTION
Issue: style sheet didn't get loaded sometime.
Cause: possibly sometime network speed caused the style sheets didn't get loaded before the page rendering.
Fix: The problem seems only happen to Primeng or bootstrap (popup) components. Some comments from internet suggested that moving style sheet definition from angular.json to styles.scss would solve the problem.

Tested locally and in local docker. Nothing broke. But since the problem never happened locally, have to confirm the fix works in testdata. 