### PR TITLE
Fix/asset hashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "scripts": {
         "build-lib": "npm run build oarng --prefix ./lib --watch",
         "build-oarlps": "npm run build oarlps --prefix ./oar-lps --watch",
+        "build-pdrlps-dev": "npm run build-dev pdr-lps --prefix ./pdr-lps --watch",
         "build-pdrlps": "npm run build pdr-lps --prefix ./pdr-lps --watch",
         "build-pdrlps:ssr": "npm run build-pdrlps; npm run build:ssr --prefix ./pdr-lps --watch",
         "build-midaslps": "npm run build midas-lps --prefix ./midas-author/lps --watch",

--- a/pdr-lps/angular.json
+++ b/pdr-lps/angular.json
@@ -53,11 +53,18 @@
             "production": {
               "budgets": [
                 {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb"
+                    "type": "anyComponentStyle",
+                    "maximumWarning": "6kb"
                 }
               ],
-              "optimization": true,
+              "optimization": {
+                    "scripts": true,
+                    "styles": {
+                    "minify": false,
+                    "inlineCritical": false
+                    },
+                    "fonts": true
+              },
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,

--- a/pdr-lps/package.json
+++ b/pdr-lps/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build-dev": "ng build",
+    "build": "ng build --configuration production",
     "test": "ng test",
     "debug-test": "ng test --watch=true --browsers=DebugChrome",
     "lint": "ng lint pdr-lps",

--- a/pdr-lps/package.json
+++ b/pdr-lps/package.json
@@ -15,7 +15,7 @@
     "lint": "ng lint pdr-lps",
     "build:client-and-server-bundles": "ng build --configuration production && ng run pdr-lps:server:production",
     "build:prerender": "npm run build:client-and-server-bundles && npm run compile:server && npm run webpack:server && npm run generate:prerender",
-    "build:ssr": "ng build && ng run pdr-lps:server",
+    "build:ssr": "ng build --configuration production && ng run pdr-lps:server:production",
     "compile:server": "tsc -p server.tsconfig.json",
     "generate:prerender": "cd dist && node prerender",
     "webpack:server": "webpack --config webpack.server.config.js --progress --color",

--- a/pdr-lps/package.json
+++ b/pdr-lps/package.json
@@ -15,7 +15,7 @@
     "lint": "ng lint pdr-lps",
     "build:client-and-server-bundles": "ng build --configuration production && ng run pdr-lps:server:production",
     "build:prerender": "npm run build:client-and-server-bundles && npm run compile:server && npm run webpack:server && npm run generate:prerender",
-    "build:ssr": "ng build --configuration production && ng run pdr-lps:server:production",
+    "build:ssr": "npm run build --configuration production && ng run pdr-lps:server",
     "compile:server": "tsc -p server.tsconfig.json",
     "generate:prerender": "cd dist && node prerender",
     "webpack:server": "webpack --config webpack.server.config.js --progress --color",

--- a/pdr-lps/package.json
+++ b/pdr-lps/package.json
@@ -15,7 +15,7 @@
     "lint": "ng lint pdr-lps",
     "build:client-and-server-bundles": "ng build --configuration production && ng run pdr-lps:server:production",
     "build:prerender": "npm run build:client-and-server-bundles && npm run compile:server && npm run webpack:server && npm run generate:prerender",
-    "build:ssr": "npm run build --configuration production && ng run pdr-lps:server",
+    "build:ssr": "npm run build && ng run pdr-lps:server:production",
     "compile:server": "tsc -p server.tsconfig.json",
     "generate:prerender": "cd dist && node prerender",
     "webpack:server": "webpack --config webpack.server.config.js --progress --color",

--- a/pdr-lps/src/environments/environment.prod.ts
+++ b/pdr-lps/src/environments/environment.prod.ts
@@ -13,7 +13,9 @@ import { LPSConfig } from 'oarlps';
 export const context = {
     production: true,
     useMetadataService: false,
-    useCustomizationService: true
+    useCustomizationService: true,
+    useMIDASDAPService: false,
+    useResourceService: true
 };
 
 export const config : LPSConfig = {
@@ -21,11 +23,21 @@ export const config : LPSConfig = {
         orgHome:     "https://nist.gov/",
         portalBase:  "https://data.nist.gov/",
         pdrHome:     "https://data.nist.gov/pdr/",
-        pdrSearch:   "https://data.nist.gov/sdp/"
+        pdrSearch: "https://data.nist.gov/sdp/",
+        mdService:   "https://data.nist.gov/rmm/"
     },
-    mdAPI: "https://data.nist.gov/rmm/records/",
+    PDRAPIs: {
+        mdSearch: "https://mdsdev.nist.gov/rmm/records/",
+        mdService: "https://mdsdev.nist.gov/od/id/",
+        metrics: "https://data.nist.gov/rmm/usagemetrics/"
+    },
+    dapEditing: {
+        serviceEndpoint: "https://mdsdev.nist.gov/midas/dap/mds3/",
+        editEnabled: false,
+    },    
+    systemVersion: "v1.3.X",
     distService: "https://data.nist.gov/od/ds/",
-    mode:        "dev",
+    mode:        "prod",
     status:      "Dev Version",
     appVersion:  "v1.1.0",
     production:  context.production,
@@ -34,8 +46,10 @@ export const config : LPSConfig = {
     screenSizeBreakPoint: 1060,
     bundleSizeAlert: 500000000,
     embedMetadata: "schema.org",
+    downloadableFileLimit: 300,
     // Decide how many seconds to wait to refresh metrics after user download one/more files
-    delayTimeForMetricsRefresh: 300  
+    delayTimeForMetricsRefresh: 300,
+    standardNISTTaxonomyURI: "https://data.nist.gov/od/dm/nist-themes/"
 }
 
 export const testdata : {} = { }


### PR DESCRIPTION
Issue: style sheet not loaded. Happened randomly.
Possible cause: distribution folder was too large because production config didn't apply to the build process.
Solution: Added production config parameter to the build command (which already had hashing enabled).
Tested locally and in docker.
Result: 
The size of the distribution folder (browser + server): 88.7MB -> 36.4MB. 
The size of browser folder: 45.3MB -> 11.6MB.

If the file size was the issue, this will definitely fix the problem.
Big thanks to @elmiomar for the insights on this issue.