### PR TITLE
Disable fontawesome icon inside primeng p-treetable to prevent Safari…

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.html
+++ b/oar-lps/libs/oarlps/src/lib/metrics/metrics.component.html
@@ -197,7 +197,7 @@
                                 style="cursor: pointer;color: rgb(255, 255, 255);" data-toggle="tooltip"
                                 title="Collapse All"></i> -->
 
-                            <fa-icon 
+                            <!-- <fa-icon 
                                 *ngIf="!isExpanded" 
                                 [class.amplified]="isMouseOver" 
                                 [icon]="faCircleArrowDown"
@@ -219,7 +219,7 @@
                                 (mouseleave)="isMouseOver = false"
                                 data-toggle="tooltip"
                                 title="Collapse All">
-                            </fa-icon>
+                            </fa-icon> -->
                         </span>
                     </span>
                     {{col.header}}


### PR DESCRIPTION
Issue: Safari crashed when opened any metrics page.
Root cause: Safari was unable to handle the fontawesome icon inside Primeng p-treetable.
Solution: temporarily disable the icon so the tree table always expanded. Long term solution is to replace Primeng with Materials.
Tested locally with Chrome, Firefox and Safari.
