### PR TITLE
Changed external link icon from faa to Primeng icon.

### DIFF
--- a/oar-lps/libs/oarlps/src/lib/landing/resultitem/resultitem.component.ts
+++ b/oar-lps/libs/oarlps/src/lib/landing/resultitem/resultitem.component.ts
@@ -47,11 +47,11 @@ export class ResultitemComponent implements OnInit {
         if(this.resultItem.landingPage.indexOf(this.resultItem.ediid.split("/").at(-1)) >= 0) {
           this.homeIconClass = "pi pi-database btn-icon";
         } else {
-          this.homeIconClass = "faa faa-external-link vertical-center";
+          this.homeIconClass = "pi pi-external-link vertical-center";
         }
       }else{
         this.homeBtnURL = this.PDRAPIURL + this.resultItem.ediid;
-        this.homeIconClass = "faa faa-external-link vertical-center";
+        this.homeIconClass = "pi pi-external-link vertical-center";
       }
 
       if(this.resultItem.description)


### PR DESCRIPTION
Issue: @elmiomar reported that in collection pages, the external link icon is missing when ediid is not present.
Screenshot of the correct display (the icon marked in yellow was missing):
<img width="1557" height="814" alt="Screenshot 2026-05-18 at 2 24 24 PM" src="https://github.com/user-attachments/assets/2895aee4-3f5d-4bba-b912-3c88871d8dbb" />

Cause: changing of Fontawesome icon usage.
Fix: changed the Fontawesome icon to Primeng icon since we still have primicon library available.
Tested locally.
 