### PR TITLE
Fixed 508 compliance issue.

### DIFF
--- a/midas-author/wizard/src/app/startwiz/components/recordname/recordname.component.html
+++ b/midas-author/wizard/src/app/startwiz/components/recordname/recordname.component.html
@@ -5,9 +5,10 @@
                 <div style="margin-bottom: .5em;">
                     We're just about finished setting up your draft publication...<p></p>
                     Give this draft a nickname that will remind you what this publication will be about.  This nickname will not appear in the publication; instead, it will appear as a label in the MIDAS portal in your list of draft publications.<p></p>
-                    Enter a nickname:
                 </div>
+                <label for="name">Enter a nickname:</label><br>
                 <input #name
+                    id="name"
                     class="input input-box"
                     type="text"
                     pInputText


### PR DESCRIPTION
Ticket:
https://sgitlab.nist.gov/oardev/publishing/-/work_items/77

The interface of the Wizard has been changed since the ticket was created. The "missing form label" error in "Publication Type" step was resolved already.

The "Very low contrast" error only occurred in local. I didn't see it in local docker nor in mdstest. And in local, WAVE didn't point out which element had problem. Maybe hidden element. So I'll just ignore this error.

<img width="1916" height="1007" alt="Screenshot 2026-06-03 at 11 22 41 AM" src="https://github.com/user-attachments/assets/4cf73dc8-fc83-4424-834c-2cf0054919a7" />


I did fixed the missing label error in "Name" step.

Tested locally and in docker.